### PR TITLE
fix(docs): fix cmake cannot build test problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ make
 
 Build and run tests:
 ```shell
-cmake .. -DYYJSON_BUILD_TESTS=ON
+cmake .. -DYYJSON_BUILD_TEST=ON
 make
 make test
 ```


### PR DESCRIPTION
Follow README and you will see:
```
$ cmake .. -DYYJSON_BUILD_TESTS=1
-- No build type selected, default to: Release
-- Configuring done
-- Generating done
CMake Warning:
  Manually-specified variables were not used by the project:

    YYJSON_BUILD_TESTS
```