### PR TITLE
Add support for JSON Patch

### DIFF
--- a/src/yyjson.h
+++ b/src/yyjson.h
@@ -1864,6 +1864,11 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_get_pointer(
                                     yyjson_mut_doc *doc, const char *pointer);
 
 
+/*==============================================================================
+ * JSON Patch API
+ *============================================================================*/
+yyjson_api_inline bool yyjson_mut_doc_patch(yyjson_mut_doc *doc,
+                                             yyjson_mut_val *val);
 
 /*==============================================================================
  * JSON Structure (Private)
@@ -3844,6 +3849,19 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_get_pointer(
     return NULL;
 }
 
+/*==============================================================================
+ * JSON Patch API (Private)
+ *============================================================================*/
+
+yyjson_api bool unsafe_yyjson_mut_doc_patch(yyjson_mut_doc *doc,
+                                        yyjson_mut_val *obj);
+
+yyjson_api_inline bool yyjson_mut_doc_patch(yyjson_mut_doc *doc,
+                                            yyjson_mut_val *val) {
+
+    if (doc && val) return unsafe_yyjson_mut_doc_patch(doc, val);
+    return false;
+}
 
 
 /*==============================================================================


### PR DESCRIPTION
This is a quick stab at JSON Patch support in py_yyjson. Creating this PR for input and to keep upstream in sync with py_yyjson (https://github.com/TkTech/py_yyjson/pull/5).

Some things that are missing:

- `test`, since there's currently no easy way to recursively compare `yyjson_mut_val`'s
- `-` to indicate end-of-array.
- Error reporting (just pass/fail)
- C tests. It's currently tested in the high-level Python tests (https://github.com/TkTech/py_yyjson/pull/5/files#diff-78e792cfafc71ca614966d5be40f70098bf25e7ef39acece8692f691102db801R67)

Things missing from the yyjson api that I ran into:

- `yyjson_mut_val_cmp()` - deep comparison of values, which would make implementing features like `test` trivial.
- `yyjson_mut_obj_remove() that takes a `const char *` instead of requiring creating a key (and thus wasting memory since we can't reclaim it).
- `yyjson_mut_obj_move()` and `yyjson_mut_arr_move()`, which allow moving a value between objects or arrays within the same document (removes the need to make copies).
- `yyjson_val_mut_copy()` that takes a `yyjson_val_mut`, which is required to move/copy values. Currently only a `yyjson_val` version exists.