### PR TITLE
Fix compilation with -Wdouble-promotion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,6 +238,7 @@ if(YYJSON_BUILD_TESTS)
                 -pedantic-errors
                 -Wmissing-prototypes
                 -Wstrict-prototypes
+                -Wdouble-promotion
                 -Wundef
             )
             target_compile_options(test_compile_c89 PRIVATE $<$<COMPILE_LANGUAGE:C>:${YYJSON_STRICT_C_FLAGS}>)

--- a/src/yyjson.h
+++ b/src/yyjson.h
@@ -2992,7 +2992,7 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_float(
     yyjson_mut_doc *doc, float *vals, size_t count) {
     yyjson_mut_arr_with_func({
         val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL;
-        val->uni.f64 = vals[i];
+        val->uni.f64 = (double)vals[i];
     });
 }
 


### PR DESCRIPTION
There was a warning when promoting float to double in `yyjson_mut_arr_with_float`