### PR TITLE
Fix MSVC build error on UWP

### DIFF
--- a/src/yyjson.c
+++ b/src/yyjson.c
@@ -5072,7 +5072,7 @@ yyjson_doc *yyjson_read_file(const char *path,
 } while(false)
     
     yyjson_read_err dummy_err;
-    yyjson_alc alc;
+    yyjson_alc alc = alc_ptr ? *alc_ptr : YYJSON_DEFAULT_ALC;
     yyjson_doc *doc;
     
     FILE *file = NULL;
@@ -5083,7 +5083,6 @@ yyjson_doc *yyjson_read_file(const char *path,
     /* validate input parameters */
     if (!err) err = &dummy_err;
     if (unlikely(!path)) return_err(INVALID_PARAMETER, "input path is NULL");
-    alc = alc_ptr ? *alc_ptr : YYJSON_DEFAULT_ALC;
     
     /* open file */
     file = fopen_safe(path, "rb"

--- a/src/yyjson.c
+++ b/src/yyjson.c
@@ -5136,7 +5136,7 @@ yyjson_doc *yyjson_read_file(const char *path,
             }
             tmp = ((u8 *)buf) + buf_size - YYJSON_PADDING_SIZE - chunk_now;
             read_size = fread_safe(tmp, chunk_now, file);
-            file_size += read_size;
+            file_size += (long)read_size;
             if (read_size != chunk_now) break;
             
             chunk_now *= 2;
@@ -5717,7 +5717,7 @@ static_noinline u8 *write_f64_raw(u8 *buf, u64 raw, bool allow_nan_and_inf) {
             buf--;
             exp_dec++;
         } while (*buf == '0');
-        exp_dec += buf - hdr - 2;
+        exp_dec += (i32)(buf - hdr - 2);
         buf += (*buf != '.');
         buf[0] = 'e';
         buf++;


### PR DESCRIPTION
Hi! I was trying to add `yyjson` to `vcpkg`: https://github.com/microsoft/vcpkg/pull/17201
The CI system of `vcpkg` reports a build error on `x64-uwp` and `arm-uwp`. The failure log can be seen here: https://dev.azure.com/vcpkg/public/_build/results?buildId=51884&view=artifacts&pathAsName=false&type=publishedArtifacts
> error C4700: uninitialized local variable 'alc' used

https://github.com/ibireme/yyjson/blob/c3a1f1f54a517dc15ba8670d969c0acdfabcd039/src/yyjson.c#L5060-L5087

`alc` is assigned a value in line 5086, but it might be referenced in line 5085.