### PR TITLE
Suppress C4800 warning (MSVC 2015 and earlier)

### DIFF
--- a/src/yyjson.h
+++ b/src/yyjson.h
@@ -355,6 +355,7 @@ extern "C" {
 #   pragma GCC diagnostic ignored "-Wunused-parameter"
 #elif defined(_MSC_VER)
 #   pragma warning(push)
+#   pragma warning(disable:4800) /* 'int': forcing value to 'true' or 'false' */
 #endif
 
 


### PR DESCRIPTION
This warning lights up a few times in the header when compiling with MSVC 2015. It was turned off by default in later versions due to noise.