### PR TITLE
Check that the type of value is array before modifying it

### DIFF
--- a/src/yyjson.h
+++ b/src/yyjson.h
@@ -2919,7 +2919,7 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_strncpy(yyjson_mut_doc *doc,
  *============================================================================*/
 
 yyjson_api_inline size_t yyjson_mut_arr_size(yyjson_mut_val *arr) {
-    return arr ? unsafe_yyjson_get_len(arr) : 0;
+    return yyjson_mut_is_arr(arr) ? unsafe_yyjson_get_len(arr) : 0;
 }
 
 yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_get(yyjson_mut_val *arr,
@@ -3206,7 +3206,7 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_strncpy(
 
 yyjson_api_inline bool yyjson_mut_arr_insert(yyjson_mut_val *arr,
                                              yyjson_mut_val *val, size_t idx) {
-    if (yyjson_likely(arr && val)) {
+    if (yyjson_likely(yyjson_mut_is_arr(arr) && val)) {
         size_t len = unsafe_yyjson_get_len(arr);
         if (yyjson_likely(idx <= len)) {
             unsafe_yyjson_set_len(arr, len + 1);
@@ -3237,7 +3237,7 @@ yyjson_api_inline bool yyjson_mut_arr_insert(yyjson_mut_val *arr,
 
 yyjson_api_inline bool yyjson_mut_arr_append(yyjson_mut_val *arr,
                                              yyjson_mut_val *val) {
-    if (yyjson_likely(arr && val)) {
+    if (yyjson_likely(yyjson_mut_is_arr(arr) && val)) {
         size_t len = unsafe_yyjson_get_len(arr);
         unsafe_yyjson_set_len(arr, len + 1);
         if (len == 0) {
@@ -3256,7 +3256,7 @@ yyjson_api_inline bool yyjson_mut_arr_append(yyjson_mut_val *arr,
 
 yyjson_api_inline bool yyjson_mut_arr_prepend(yyjson_mut_val *arr,
                                               yyjson_mut_val *val) {
-    if (yyjson_likely(arr && val)) {
+    if (yyjson_likely(yyjson_mut_is_arr(arr) && val)) {
         size_t len = unsafe_yyjson_get_len(arr);
         unsafe_yyjson_set_len(arr, len + 1);
         if (len == 0) {
@@ -3276,7 +3276,7 @@ yyjson_api_inline bool yyjson_mut_arr_prepend(yyjson_mut_val *arr,
 yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_replace(yyjson_mut_val *arr,
                                                          size_t idx,
                                                          yyjson_mut_val *val) {
-    if (yyjson_likely(arr && val)) {
+    if (yyjson_likely(yyjson_mut_is_arr(arr) && val)) {
         size_t len = unsafe_yyjson_get_len(arr);
         if (yyjson_likely(idx < len)) {
             if (yyjson_likely(len > 1)) {
@@ -3303,7 +3303,7 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_replace(yyjson_mut_val *arr,
 
 yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_remove(yyjson_mut_val *arr,
                                                         size_t idx) {
-    if (yyjson_likely(arr)) {
+    if (yyjson_likely(yyjson_mut_is_arr(arr))) {
         size_t len = unsafe_yyjson_get_len(arr);
         if (yyjson_likely(idx < len)) {
             unsafe_yyjson_set_len(arr, len - 1);
@@ -3327,7 +3327,7 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_remove(yyjson_mut_val *arr,
 
 yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_remove_first(
     yyjson_mut_val *arr) {
-    if (yyjson_likely(arr)) {
+    if (yyjson_likely(yyjson_mut_is_arr(arr))) {
         size_t len = unsafe_yyjson_get_len(arr);
         if (len > 1) {
             yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
@@ -3346,7 +3346,7 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_remove_first(
 
 yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_remove_last(
     yyjson_mut_val *arr) {
-    if (yyjson_likely(arr)) {
+    if (yyjson_likely(yyjson_mut_is_arr(arr))) {
         size_t len = unsafe_yyjson_get_len(arr);
         if (yyjson_likely(len > 1)) {
             yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
@@ -3368,7 +3368,7 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_remove_last(
 
 yyjson_api_inline bool yyjson_mut_arr_remove_range(yyjson_mut_val *arr,
                                                    size_t _idx, size_t _len) {
-    if (yyjson_likely(arr)) {
+    if (yyjson_likely(yyjson_mut_is_arr(arr))) {
         yyjson_mut_val *prev, *next;
         bool tail_removed;
         size_t len = unsafe_yyjson_get_len(arr);
@@ -3408,7 +3408,7 @@ yyjson_api_inline bool yyjson_mut_arr_add_val(yyjson_mut_val *arr,
 
 yyjson_api_inline bool yyjson_mut_arr_add_null(yyjson_mut_doc *doc,
                                                yyjson_mut_val *arr) {
-    if (yyjson_likely(doc && arr)) {
+    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
         yyjson_mut_val *val = yyjson_mut_null(doc);
         return yyjson_mut_arr_append(arr, val);
     }
@@ -3417,7 +3417,7 @@ yyjson_api_inline bool yyjson_mut_arr_add_null(yyjson_mut_doc *doc,
 
 yyjson_api_inline bool yyjson_mut_arr_add_true(yyjson_mut_doc *doc,
                                                yyjson_mut_val *arr) {
-    if (yyjson_likely(doc && arr)) {
+    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
         yyjson_mut_val *val = yyjson_mut_true(doc);
         return yyjson_mut_arr_append(arr, val);
     }
@@ -3426,7 +3426,7 @@ yyjson_api_inline bool yyjson_mut_arr_add_true(yyjson_mut_doc *doc,
 
 yyjson_api_inline bool yyjson_mut_arr_add_false(yyjson_mut_doc *doc,
                                                 yyjson_mut_val *arr) {
-    if (yyjson_likely(doc && arr)) {
+    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
         yyjson_mut_val *val = yyjson_mut_false(doc);
         return yyjson_mut_arr_append(arr, val);
     }
@@ -3436,7 +3436,7 @@ yyjson_api_inline bool yyjson_mut_arr_add_false(yyjson_mut_doc *doc,
 yyjson_api_inline bool yyjson_mut_arr_add_bool(yyjson_mut_doc *doc,
                                                yyjson_mut_val *arr,
                                                bool _val) {
-    if (yyjson_likely(doc && arr)) {
+    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
         yyjson_mut_val *val = yyjson_mut_bool(doc, _val);
         return yyjson_mut_arr_append(arr, val);
     }
@@ -3446,7 +3446,7 @@ yyjson_api_inline bool yyjson_mut_arr_add_bool(yyjson_mut_doc *doc,
 yyjson_api_inline bool yyjson_mut_arr_add_uint(yyjson_mut_doc *doc,
                                                yyjson_mut_val *arr,
                                                uint64_t num) {
-    if (yyjson_likely(doc && arr)) {
+    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
         yyjson_mut_val *val = yyjson_mut_uint(doc, num);
         return yyjson_mut_arr_append(arr, val);
     }
@@ -3456,7 +3456,7 @@ yyjson_api_inline bool yyjson_mut_arr_add_uint(yyjson_mut_doc *doc,
 yyjson_api_inline bool yyjson_mut_arr_add_sint(yyjson_mut_doc *doc,
                                                yyjson_mut_val *arr,
                                                int64_t num) {
-    if (yyjson_likely(doc && arr)) {
+    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
         yyjson_mut_val *val = yyjson_mut_sint(doc, num);
         return yyjson_mut_arr_append(arr, val);
     }
@@ -3466,7 +3466,7 @@ yyjson_api_inline bool yyjson_mut_arr_add_sint(yyjson_mut_doc *doc,
 yyjson_api_inline bool yyjson_mut_arr_add_int(yyjson_mut_doc *doc,
                                               yyjson_mut_val *arr,
                                               int64_t num) {
-    if (yyjson_likely(doc && arr)) {
+    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
         yyjson_mut_val *val = yyjson_mut_sint(doc, num);
         return yyjson_mut_arr_append(arr, val);
     }
@@ -3476,7 +3476,7 @@ yyjson_api_inline bool yyjson_mut_arr_add_int(yyjson_mut_doc *doc,
 yyjson_api_inline bool yyjson_mut_arr_add_real(yyjson_mut_doc *doc,
                                                yyjson_mut_val *arr,
                                                double num) {
-    if (yyjson_likely(doc && arr)) {
+    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
         yyjson_mut_val *val = yyjson_mut_real(doc, num);
         return yyjson_mut_arr_append(arr, val);
     }
@@ -3486,7 +3486,7 @@ yyjson_api_inline bool yyjson_mut_arr_add_real(yyjson_mut_doc *doc,
 yyjson_api_inline bool yyjson_mut_arr_add_str(yyjson_mut_doc *doc,
                                               yyjson_mut_val *arr,
                                               const char *str) {
-    if (yyjson_likely(doc && arr)) {
+    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
         yyjson_mut_val *val = yyjson_mut_str(doc, str);
         return yyjson_mut_arr_append(arr, val);
     }
@@ -3496,7 +3496,7 @@ yyjson_api_inline bool yyjson_mut_arr_add_str(yyjson_mut_doc *doc,
 yyjson_api_inline bool yyjson_mut_arr_add_strn(yyjson_mut_doc *doc,
                                                yyjson_mut_val *arr,
                                                const char *str, size_t len) {
-    if (yyjson_likely(doc && arr)) {
+    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
         yyjson_mut_val *val = yyjson_mut_strn(doc, str, len);
         return yyjson_mut_arr_append(arr, val);
     }
@@ -3506,7 +3506,7 @@ yyjson_api_inline bool yyjson_mut_arr_add_strn(yyjson_mut_doc *doc,
 yyjson_api_inline bool yyjson_mut_arr_add_strcpy(yyjson_mut_doc *doc,
                                                  yyjson_mut_val *arr,
                                                  const char *str) {
-    if (yyjson_likely(doc && arr)) {
+    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
         yyjson_mut_val *val = yyjson_mut_strcpy(doc, str);
         return yyjson_mut_arr_append(arr, val);
     }
@@ -3516,7 +3516,7 @@ yyjson_api_inline bool yyjson_mut_arr_add_strcpy(yyjson_mut_doc *doc,
 yyjson_api_inline bool yyjson_mut_arr_add_strncpy(yyjson_mut_doc *doc,
                                                   yyjson_mut_val *arr,
                                                   const char *str, size_t len) {
-    if (yyjson_likely(doc && arr)) {
+    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
         yyjson_mut_val *val = yyjson_mut_strncpy(doc, str, len);
         return yyjson_mut_arr_append(arr, val);
     }
@@ -3525,14 +3525,20 @@ yyjson_api_inline bool yyjson_mut_arr_add_strncpy(yyjson_mut_doc *doc,
 
 yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_add_arr(yyjson_mut_doc *doc,
                                                          yyjson_mut_val *arr) {
-    yyjson_mut_val *val = yyjson_mut_arr(doc);
-    return yyjson_mut_arr_append(arr, val) ? val : NULL;
+    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
+        yyjson_mut_val *val = yyjson_mut_arr(doc);
+        return yyjson_mut_arr_append(arr, val) ? val : NULL;
+    }
+    return NULL;
 }
 
 yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_add_obj(yyjson_mut_doc *doc,
                                                          yyjson_mut_val *arr) {
-    yyjson_mut_val *val = yyjson_mut_obj(doc);
-    return yyjson_mut_arr_append(arr, val) ? val : NULL;
+    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
+        yyjson_mut_val *val = yyjson_mut_obj(doc);
+        return yyjson_mut_arr_append(arr, val) ? val : NULL;
+    }
+    return NULL;
 }
 
 


### PR DESCRIPTION
Unless there's a specific reason not to do it, I think that the type of `yyjson_mut_val` should be checked, that it is an array, before modifying in yyjson_mut_arr functions.

For yyjson_mut_obj the type is always checked.

For yyjson_val array the type is also already checked.