### PR TITLE
Append soname to the library filename

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ endif()
 # ------------------------------------------------------------------------------
 # Library
 add_library(yyjson src/yyjson.h src/yyjson.c)
+set_target_properties(yyjson PROPERTIES VERSION ${PROJECT_VERSION})
 target_include_directories(yyjson PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>)
 
 


### PR DESCRIPTION
This will make it easier for packagers of yyjson to install its library, since most Linux distributions tend to install libraries with the soname in the end of filename.