### PR TITLE
Add yyjson_equals

### DIFF
--- a/src/yyjson.c
+++ b/src/yyjson.c
@@ -1388,6 +1388,84 @@ yyjson_api yyjson_mut_val *yyjson_mut_val_mut_copy(yyjson_mut_doc *doc,
     return NULL;
 }
 
+static_inline bool unsafe_yyjson_num_equals(void *lhs, void *rhs) {
+    yyjson_val_uni *luni = &((yyjson_val *)lhs)->uni;
+    yyjson_val_uni *runi = &((yyjson_val *)rhs)->uni;
+    yyjson_subtype lt = unsafe_yyjson_get_subtype(lhs);
+    yyjson_subtype rt = unsafe_yyjson_get_subtype(rhs);
+    if (lt == rt)
+        return luni->u64 == runi->u64;
+    if (lt == YYJSON_SUBTYPE_SINT && rt == YYJSON_SUBTYPE_UINT)
+        return luni->i64 >= 0 && luni->u64 == runi->u64;
+    if (lt == YYJSON_SUBTYPE_UINT && rt == YYJSON_SUBTYPE_SINT)
+        return runi->i64 >= 0 && luni->u64 == runi->u64;
+    return false;
+}
+
+static_inline bool unsafe_yyjson_str_equals(void *lhs, void *rhs) {
+    usize len = unsafe_yyjson_get_len(lhs);
+    if (len != unsafe_yyjson_get_len(rhs)) return false;
+    return 0 == len ||
+           0 == memcmp(unsafe_yyjson_get_str(lhs),
+                       unsafe_yyjson_get_str(rhs), len);
+}
+
+yyjson_api bool unsafe_yyjson_equals(yyjson_val *lhs, yyjson_val *rhs) {
+    yyjson_type type = unsafe_yyjson_get_type(lhs);
+    if (type != unsafe_yyjson_get_type(rhs)) return false;
+    
+    switch (type) {
+        case YYJSON_TYPE_OBJ: {
+            usize len = unsafe_yyjson_get_len(lhs);
+            if (len != unsafe_yyjson_get_len(rhs)) return false;
+            if (len > 0) {
+                yyjson_obj_iter iter;
+                yyjson_obj_iter_init(rhs, &iter);
+                lhs = unsafe_yyjson_get_first(lhs);
+                while (len-- > 0) {
+                    rhs = yyjson_obj_iter_getn(&iter, lhs->uni.str,
+                                               unsafe_yyjson_get_len(lhs));
+                    if (!rhs || !unsafe_yyjson_equals(lhs + 1, rhs))
+                        return false;
+                    lhs = unsafe_yyjson_get_next(lhs + 1);
+                }
+            }
+            /* yyjson allows duplicate keys, so the check may be inaccurate */
+            return true;
+        }
+        
+        case YYJSON_TYPE_ARR: {
+            usize len = unsafe_yyjson_get_len(lhs);
+            if (len != unsafe_yyjson_get_len(rhs)) return false;
+            if (len > 0) {
+                lhs = unsafe_yyjson_get_first(lhs);
+                rhs = unsafe_yyjson_get_first(rhs);
+                while (len-- > 0) {
+                    if (!unsafe_yyjson_equals(lhs, rhs))
+                        return false;
+                    lhs = unsafe_yyjson_get_next(lhs);
+                    rhs = unsafe_yyjson_get_next(rhs);
+                }
+            }
+            return true;
+        }
+        
+        case YYJSON_TYPE_NUM:
+            return unsafe_yyjson_num_equals(lhs, rhs);
+        
+        case YYJSON_TYPE_RAW:
+        case YYJSON_TYPE_STR:
+            return unsafe_yyjson_str_equals(lhs, rhs);
+        
+        case YYJSON_TYPE_NULL:
+        case YYJSON_TYPE_BOOL:
+            return lhs->tag == rhs->tag;
+        
+        default:
+            return false;
+    }
+}
+
 bool unsafe_yyjson_mut_equals(yyjson_mut_val *lhs, yyjson_mut_val *rhs) {
     yyjson_type type = unsafe_yyjson_get_type(lhs);
     if (type != unsafe_yyjson_get_type(rhs)) return false;
@@ -1428,26 +1506,12 @@ bool unsafe_yyjson_mut_equals(yyjson_mut_val *lhs, yyjson_mut_val *rhs) {
             return true;
         }
         
-        case YYJSON_TYPE_NUM: {
-            yyjson_subtype lt = unsafe_yyjson_get_subtype(lhs);
-            yyjson_subtype rt = unsafe_yyjson_get_subtype(rhs);
-            if (lt == rt)
-                return lhs->uni.u64 == rhs->uni.u64;
-            if (lt == YYJSON_SUBTYPE_SINT && rt == YYJSON_SUBTYPE_UINT)
-                return lhs->uni.i64 >= 0 && lhs->uni.u64 == rhs->uni.u64;
-            if (lt == YYJSON_SUBTYPE_UINT && rt == YYJSON_SUBTYPE_SINT)
-                return rhs->uni.i64 >= 0 && lhs->uni.u64 == rhs->uni.u64;
-            return false;
-        }
+        case YYJSON_TYPE_NUM:
+            return unsafe_yyjson_num_equals(lhs, rhs);
         
         case YYJSON_TYPE_RAW:
-        case YYJSON_TYPE_STR: {
-            usize len = unsafe_yyjson_get_len(lhs);
-            if (len != unsafe_yyjson_get_len(rhs)) return false;
-            return 0 == len ||
-                   0 == memcmp(unsafe_yyjson_get_str(lhs),
-                               unsafe_yyjson_get_str(rhs), len);
-        }
+        case YYJSON_TYPE_STR:
+            return unsafe_yyjson_str_equals(lhs, rhs);
         
         case YYJSON_TYPE_NULL:
         case YYJSON_TYPE_BOOL:

--- a/src/yyjson.h
+++ b/src/yyjson.h
@@ -2783,10 +2783,7 @@ yyjson_api_inline bool yyjson_obj_iter_init(yyjson_val *obj,
         iter->obj = obj;
         return true;
     }
-    if (iter) {
-        iter->idx = 0;
-        iter->max = 0;
-    }
+    if (iter) memset(iter, 0, sizeof(yyjson_obj_iter));
     return false;
 }
 

--- a/src/yyjson.h
+++ b/src/yyjson.h
@@ -1272,6 +1272,8 @@ yyjson_api_inline bool yyjson_equals_str(yyjson_val *val, const char *str);
 yyjson_api_inline bool yyjson_equals_strn(yyjson_val *val, const char *str,
                                           size_t len);
 
+/** Returns whether two JSON values are equal (deep compare). */
+yyjson_api_inline bool yyjson_equals(yyjson_val *lhs, yyjson_val *rhs);
 
 
 /*==============================================================================
@@ -2637,6 +2639,15 @@ yyjson_api_inline bool yyjson_equals_strn(yyjson_val *val, const char *str,
         return unsafe_yyjson_equals_strn(val, str, len);
     }
     return false;
+}
+
+yyjson_api bool unsafe_yyjson_equals(yyjson_val *lhs, yyjson_val *rhs);
+
+yyjson_api_inline bool yyjson_equals(yyjson_val *lhs, yyjson_val *rhs) {
+    if (yyjson_unlikely(!lhs || !rhs))
+        return false;
+    
+    return unsafe_yyjson_equals(lhs, rhs);
 }
 
 


### PR DESCRIPTION
It is basically the same as `yyjson_mut_equals` but with slightly different object and array traversal.

Added `unsafe_yyjson_num_equals` and `unsafe_yyjson_str_equals` since the comparison of
numbers and strings is common for mutable and immutable values.

Added tests for `yyjson_equals`.

Also fixed `yyjson_obj_iter_init`.

When iter initialization fails, we should zero all bytes in iter struct,
like it is done in all other iter functions but was missing in this one.

Otherwise compiler gives a lot of `maybe-uninitialized` warnings.