### PR TITLE
Raw values fixes and improvements

### DIFF
--- a/src/yyjson.c
+++ b/src/yyjson.c
@@ -7347,6 +7347,15 @@ doc_begin:
 val_begin:
     val_type = unsafe_yyjson_get_type(val);
     switch (val_type) {
+        case YYJSON_TYPE_RAW:
+            str_len = unsafe_yyjson_get_len(val);
+            str_ptr = (const u8 *)unsafe_yyjson_get_str(val);
+            check_str_len(str_len);
+            incr_len(str_len + 2);
+            cur = write_raw(cur, str_ptr, str_len);
+            *cur++ = ',';
+            break;
+            
         case YYJSON_TYPE_STR:
             is_key = ((u8)ctn_obj & (u8)~ctn_len);
             str_len = unsafe_yyjson_get_len(val);
@@ -7514,6 +7523,16 @@ doc_begin:
 val_begin:
     val_type = unsafe_yyjson_get_type(val);
     switch (val_type) {
+        case YYJSON_TYPE_RAW:
+            str_len = unsafe_yyjson_get_len(val);
+            str_ptr = (const u8 *)unsafe_yyjson_get_str(val);
+            check_str_len(str_len);
+            incr_len(str_len + 3);
+            cur = write_raw(cur, str_ptr, str_len);
+            *cur++ = ',';
+            *cur++ = '\n';
+            break;
+            
         case YYJSON_TYPE_STR:
             is_key = ((u8)ctn_obj & (u8)~ctn_len);
             no_indent = ((u8)ctn_obj & (u8)ctn_len);

--- a/src/yyjson.h
+++ b/src/yyjson.h
@@ -1593,11 +1593,32 @@ yyjson_api_inline bool yyjson_mut_equals(yyjson_mut_val *lhs,
  *============================================================================*/
 
 /** Creates and returns a raw value, returns NULL on error.
+    The input value should be a valid UTF-8 encoded string with null-terminator.
+    @warning The input string is not copied, you should keep this string
+    unmodified for the lifetime of this document. */
+yyjson_api_inline yyjson_mut_val *yyjson_mut_raw(yyjson_mut_doc *doc,
+                                                 const char *str);
+
+/** Creates and returns a raw value, returns NULL on error.
+    The input value should be a valid UTF-8 encoded string.
+    @warning The input string is not copied, you should keep this string
+    unmodified for the lifetime of this document. */
+yyjson_api_inline yyjson_mut_val *yyjson_mut_rawn(yyjson_mut_doc *doc,
+                                                  const char *str,
+                                                  size_t len);
+
+/** Creates and returns a raw value, returns NULL on error.
+    The input value should be a valid UTF-8 encoded string with null-terminator.
+    The input string is copied and held by the document. */
+yyjson_api_inline yyjson_mut_val *yyjson_mut_rawcpy(yyjson_mut_doc *doc,
+                                                    const char *str);
+
+/** Creates and returns a raw value, returns NULL on error.
     The input value should be a valid UTF-8 encoded string.
     The input string is copied and held by the document. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_raw(yyjson_mut_doc *doc,
-                                                 const char *str,
-                                                 size_t len);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_rawncpy(yyjson_mut_doc *doc,
+                                                     const char *str,
+                                                     size_t len);
 
 /** Creates and returns a null value, returns NULL on error. */
 yyjson_api_inline yyjson_mut_val *yyjson_mut_null(yyjson_mut_doc *doc);
@@ -3094,8 +3115,34 @@ yyjson_api_inline bool yyjson_mut_equals(yyjson_mut_val *lhs,
  *============================================================================*/
 
 yyjson_api_inline yyjson_mut_val *yyjson_mut_raw(yyjson_mut_doc *doc,
-                                                 const char *str,
-                                                 size_t len) {
+                                                 const char *str) {
+    if (yyjson_likely(str)) return yyjson_mut_rawn(doc, str, strlen(str));
+    return NULL;
+}
+
+yyjson_api_inline yyjson_mut_val *yyjson_mut_rawn(yyjson_mut_doc *doc,
+                                                  const char *str,
+                                                  size_t len) {
+    if (yyjson_likely(doc && str)) {
+        yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
+        if (yyjson_likely(val)) {
+            val->tag = ((uint64_t)len << YYJSON_TAG_BIT) | YYJSON_TYPE_RAW;
+            val->uni.str = str;
+            return val;
+        }
+    }
+    return NULL;
+}
+
+yyjson_api_inline yyjson_mut_val *yyjson_mut_rawcpy(yyjson_mut_doc *doc,
+                                                    const char *str) {
+    if (yyjson_likely(str)) return yyjson_mut_rawncpy(doc, str, strlen(str));
+    return NULL;
+}
+
+yyjson_api_inline yyjson_mut_val *yyjson_mut_rawncpy(yyjson_mut_doc *doc,
+                                                     const char *str,
+                                                     size_t len) {
     if (yyjson_likely(doc && str)) {
         yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
         char *new_str = unsafe_yyjson_mut_strncpy(doc, str, len);


### PR DESCRIPTION
I need creating raw values when their contents is already allocated in the doc, so I don't need extra copying.

I added 4 raw values creation functions, which are basically the same as `mut_str` functions, except
the value type is YYJSON_TYPE_RAW.

Also fixed writing raw values in `mut_val_write_opts`, seems like the raw values support was forgotten there.