### PR TITLE
Add option to allow writing invalid unicode

### DIFF
--- a/misc/make_tables.c
+++ b/misc/make_tables.c
@@ -317,6 +317,10 @@ static void make_u64_pow10_table(void) {
 #define CHAR_ESC_UTF8_2 3 /* 2-byte UTF-8 character, escaped as '\uXXXX'. */
 #define CHAR_ESC_UTF8_3 4 /* 3-byte UTF-8 character, escaped as '\uXXXX'. */
 #define CHAR_ESC_UTF8_4 5 /* 4-byte UTF-8 character, escaped as two '\uXXXX'. */
+#define CHAR_ESC_INV8_1 6 /* CHAR_ESC_UTF8_1 with unicode validation. */
+#define CHAR_ESC_INV8_2 7 /* CHAR_ESC_UTF8_2 with unicode validation. */
+#define CHAR_ESC_INV8_3 8 /* CHAR_ESC_UTF8_3 with unicode validation. */
+#define CHAR_ESC_INV8_4 9 /* CHAR_ESC_UTF8_4 with unicode validation. */
 
 static void make_esc_table(void) {
     u8 table[256];
@@ -421,6 +425,38 @@ static void make_esc_table(void) {
     printf("};\n");
     printf("\n");
     
+    // esc_table_unicode_inv
+    memset(table, CHAR_ESC_NONE, 256);
+    for (int i = 0; i <= 0x1F; i++) {
+        table[i] = CHAR_ESC_INV8_1;
+    }
+    table['\b'] = CHAR_ESC_ASCII;
+    table['\t'] = CHAR_ESC_ASCII;
+    table['\n'] = CHAR_ESC_ASCII;
+    table['\f'] = CHAR_ESC_ASCII;
+    table['\r'] = CHAR_ESC_ASCII;
+    table['\\'] = CHAR_ESC_ASCII;
+    table['"'] = CHAR_ESC_ASCII;
+    for (int i = 0; i <= 0xFF; i++) {
+        if ((i & 0xE0) == 0xC0) table[i] = CHAR_ESC_INV8_2;
+        if ((i & 0xF0) == 0xE0) table[i] = CHAR_ESC_INV8_3;
+        if ((i & 0xF8) == 0xF0) table[i] = CHAR_ESC_INV8_4;
+    }
+    
+    printf("static const char_esc_type esc_table_unicode_inv[256] = {\n");
+    for (int i = 0; i < table_len; i++) {
+        bool is_head = ((i % line_len) == 0);
+        bool is_tail = ((i % line_len) == line_len - 1);
+        bool is_last = i + 1 == table_len;
+        
+        if (is_head) printf("    ");
+        printf("%d", table[i]);
+        if (i + 1 < table_len) printf(",");
+        if (!is_tail && !is_last) printf(" "); else printf("\n");
+    }
+    printf("};\n");
+    printf("\n");
+    
     // esc_table_unicode_with_slashes
     memset(table, CHAR_ESC_NONE, 256);
     for (int i = 0; i <= 0x1F; i++) {
@@ -441,6 +477,39 @@ static void make_esc_table(void) {
     }
     
     printf("static const char_esc_type esc_table_unicode_with_slashes[256] = {\n");
+    for (int i = 0; i < table_len; i++) {
+        bool is_head = ((i % line_len) == 0);
+        bool is_tail = ((i % line_len) == line_len - 1);
+        bool is_last = i + 1 == table_len;
+        
+        if (is_head) printf("    ");
+        printf("%d", table[i]);
+        if (i + 1 < table_len) printf(",");
+        if (!is_tail && !is_last) printf(" "); else printf("\n");
+    }
+    printf("};\n");
+    printf("\n");
+    
+    // esc_table_unicode_with_slashes_inv
+    memset(table, CHAR_ESC_NONE, 256);
+    for (int i = 0; i <= 0x1F; i++) {
+        table[i] = CHAR_ESC_INV8_1;
+    }
+    table['\b'] = CHAR_ESC_ASCII;
+    table['\t'] = CHAR_ESC_ASCII;
+    table['\n'] = CHAR_ESC_ASCII;
+    table['\f'] = CHAR_ESC_ASCII;
+    table['\r'] = CHAR_ESC_ASCII;
+    table['\\'] = CHAR_ESC_ASCII;
+    table['/'] = CHAR_ESC_ASCII;
+    table['"'] = CHAR_ESC_ASCII;
+    for (int i = 0; i <= 0xFF; i++) {
+        if ((i & 0xE0) == 0xC0) table[i] = CHAR_ESC_INV8_2;
+        if ((i & 0xF0) == 0xE0) table[i] = CHAR_ESC_INV8_3;
+        if ((i & 0xF8) == 0xF0) table[i] = CHAR_ESC_INV8_4;
+    }
+    
+    printf("static const char_esc_type esc_table_unicode_with_slashes_inv[256] = {\n");
     for (int i = 0; i < table_len; i++) {
         bool is_head = ((i % line_len) == 0);
         bool is_tail = ((i % line_len) == line_len - 1);

--- a/src/yyjson.c
+++ b/src/yyjson.c
@@ -6322,6 +6322,10 @@ typedef u8 char_esc_type;
 #define CHAR_ESC_UTF8_2 3 /* 2-byte UTF-8 character, escaped as '\uXXXX'. */
 #define CHAR_ESC_UTF8_3 4 /* 3-byte UTF-8 character, escaped as '\uXXXX'. */
 #define CHAR_ESC_UTF8_4 5 /* 4-byte UTF-8 character, escaped as two '\uXXXX'. */
+#define CHAR_ESC_INV8_1 6 /* CHAR_ESC_UTF8_1 with unicode validation. */
+#define CHAR_ESC_INV8_2 7 /* CHAR_ESC_UTF8_2 with unicode validation. */
+#define CHAR_ESC_INV8_3 8 /* CHAR_ESC_UTF8_3 with unicode validation. */
+#define CHAR_ESC_INV8_4 9 /* CHAR_ESC_UTF8_4 with unicode validation. */
 
 /** Character escape type table: don't escape unicode, don't escape '/'.
     (generate with misc/make_tables.c) */
@@ -6405,6 +6409,50 @@ static const char_esc_type esc_table_unicode_with_slashes[256] = {
     3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
     4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
     5, 5, 5, 5, 5, 5, 5, 5, 0, 0, 0, 0, 0, 0, 0, 0
+};
+
+/** Character escape type table: escape unicode, don't escape '/'.
+    Perform unicode validation and copy invalid sequences per-byte.
+    (generate with misc/make_tables.c) */
+static const char_esc_type esc_table_unicode_inv[256] = {
+    6, 6, 6, 6, 6, 6, 6, 6, 1, 1, 1, 6, 1, 1, 6, 6,
+    6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,
+    0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+    7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+    8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
+    9, 9, 9, 9, 9, 9, 9, 9, 0, 0, 0, 0, 0, 0, 0, 0
+};
+
+/** Character escape type table: escape unicode, escape '/'.
+    Perform unicode validation and copy invalid sequences per-byte.
+    (generate with misc/make_tables.c) */
+static const char_esc_type esc_table_unicode_with_slashes_inv[256] = {
+    6, 6, 6, 6, 6, 6, 6, 6, 1, 1, 1, 6, 1, 1, 6, 6,
+    6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,
+    0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+    7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+    8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
+    9, 9, 9, 9, 9, 9, 9, 9, 0, 0, 0, 0, 0, 0, 0, 0
 };
 
 /** Escaped hex character table: ["00" "01" "02" ... "FD" "FE" "FF"].
@@ -6551,9 +6599,17 @@ static_inline const char_esc_type *get_esc_table_with_flag(
     yyjson_read_flag flg) {
     if (unlikely(flg & YYJSON_WRITE_ESCAPE_UNICODE)) {
         if (unlikely(flg & YYJSON_WRITE_ESCAPE_SLASHES)) {
-            return esc_table_unicode_with_slashes;
+            if (unlikely(flg & YYJSON_WRITE_ALLOW_INVALID_UNICODE)) {
+                return esc_table_unicode_with_slashes_inv;
+            } else {
+                return esc_table_unicode_with_slashes;
+            }
         } else {
-            return esc_table_unicode;
+            if (unlikely(flg & YYJSON_WRITE_ALLOW_INVALID_UNICODE)) {
+                return esc_table_unicode_inv;
+            } else {
+                return esc_table_unicode;
+            }
         }
     } else {
         if (unlikely(flg & YYJSON_WRITE_ESCAPE_SLASHES)) {
@@ -6640,6 +6696,7 @@ copy_next:
                 str += 1;
                 continue;
             }
+            case CHAR_ESC_INV8_1:
             case CHAR_ESC_UTF8_1: {
                 ((v32 *)cur)[0] = v32_make('\\', 'u', '0', '0');
                 ((v16 *)cur)[2] = ((const v16 *)esc_hex_char_table)[*str];
@@ -6647,6 +6704,13 @@ copy_next:
                 str += 1;
                 continue;
             }
+            case CHAR_ESC_INV8_2: {
+                if (unlikely(end - str < 2)) {
+                    *cur++ = *str++;
+                    goto copy_char;
+                }
+            }
+            /* fallthrough */
             case CHAR_ESC_UTF8_2: {
                 u16 u = (u16)(((u16)(str[0] & 0x1F) << 6) |
                               ((u16)(str[1] & 0x3F) << 0));
@@ -6657,6 +6721,13 @@ copy_next:
                 str += 2;
                 continue;
             }
+            case CHAR_ESC_INV8_3: {
+                if (unlikely(end - str < 3)) {
+                    *cur++ = *str++;
+                    goto copy_char;
+                }
+            }
+            /* fallthrough */
             case CHAR_ESC_UTF8_3: {
                 u16 u = (u16)(((u16)(str[0] & 0x0F) << 12) |
                               ((u16)(str[1] & 0x3F) << 6) |
@@ -6668,6 +6739,13 @@ copy_next:
                 str += 3;
                 continue;
             }
+            case CHAR_ESC_INV8_4: {
+                if (unlikely(end - str < 4)) {
+                    *cur++ = *str++;
+                    goto copy_char;
+                }
+            }
+            /* fallthrough */
             case CHAR_ESC_UTF8_4: {
                 u32 hi, lo;
                 u32 u = ((u32)(str[0] & 0x07) << 18) |
@@ -7251,6 +7329,11 @@ char *yyjson_val_write_opts(const yyjson_val *val,
         return NULL;
     }
     
+#if YYJSON_DISABLE_NON_STANDARD
+    /*flg &= ~YYJSON_WRITE_ALLOW_INF_AND_NAN;*/
+    flg &= ~YYJSON_WRITE_ALLOW_INVALID_UNICODE;
+#endif
+    
     if (!unsafe_yyjson_is_ctn(root) || unsafe_yyjson_get_len(root) == 0) {
         return (char *)yyjson_write_single(root, flg, alc, dat_len, err);
     } else if (flg & YYJSON_WRITE_PRETTY) {
@@ -7731,6 +7814,11 @@ char *yyjson_mut_val_write_opts(const yyjson_mut_val *val,
         err->code = YYJSON_WRITE_ERROR_INVALID_PARAMETER;
         return NULL;
     }
+    
+#if YYJSON_DISABLE_NON_STANDARD
+    /*flg &= ~YYJSON_WRITE_ALLOW_INF_AND_NAN;*/
+    flg &= ~YYJSON_WRITE_ALLOW_INVALID_UNICODE;
+#endif
     
     if (!unsafe_yyjson_is_ctn(root) || unsafe_yyjson_get_len(root) == 0) {
         return (char *)yyjson_mut_write_single(root, flg, alc, dat_len, err);

--- a/src/yyjson.h
+++ b/src/yyjson.h
@@ -64,6 +64,7 @@
        YYJSON_READ_ALLOW_COMMENTS
        YYJSON_READ_ALLOW_TRAILING_COMMAS
        YYJSON_WRITE_ALLOW_INF_AND_NAN
+       YYJSON_WRITE_ALLOW_INVALID_UNICODE
    This may reduce binary size, and increase performance slightly. */
 #ifndef YYJSON_DISABLE_NON_STANDARD
 #endif
@@ -732,24 +733,27 @@ typedef uint32_t yyjson_write_flag;
     - Report error on inf or nan number.
     - Do not validate string encoding.
     - Do not escape unicode or slash. */
-static const yyjson_write_flag YYJSON_WRITE_NOFLAG              = 0 << 0;
+static const yyjson_write_flag YYJSON_WRITE_NOFLAG                 = 0 << 0;
 
 /** Write JSON pretty with 4 space indent. */
-static const yyjson_write_flag YYJSON_WRITE_PRETTY              = 1 << 0;
+static const yyjson_write_flag YYJSON_WRITE_PRETTY                 = 1 << 0;
 
 /** Escape unicode as `uXXXX`, make the output ASCII only. */
-static const yyjson_write_flag YYJSON_WRITE_ESCAPE_UNICODE      = 1 << 1;
+static const yyjson_write_flag YYJSON_WRITE_ESCAPE_UNICODE         = 1 << 1;
 
 /** Escape '/' as '\/'. */
-static const yyjson_write_flag YYJSON_WRITE_ESCAPE_SLASHES      = 1 << 2;
+static const yyjson_write_flag YYJSON_WRITE_ESCAPE_SLASHES         = 1 << 2;
 
 /** Write inf and nan number as 'Infinity' and 'NaN' literal (non-standard). */
-static const yyjson_write_flag YYJSON_WRITE_ALLOW_INF_AND_NAN   = 1 << 3;
+static const yyjson_write_flag YYJSON_WRITE_ALLOW_INF_AND_NAN      = 1 << 3;
 
 /** Write inf and nan number as null literal.
     This flag will override `YYJSON_WRITE_ALLOW_INF_AND_NAN` flag. */
-static const yyjson_write_flag YYJSON_WRITE_INF_AND_NAN_AS_NULL = 1 << 4;
+static const yyjson_write_flag YYJSON_WRITE_INF_AND_NAN_AS_NULL    = 1 << 4;
 
+/** When `YYJSON_WRITE_ESCAPE_UNICODE` flag is set don't try to parse
+    malformed unicode sequences, but copy them per-byte instead. */
+static const yyjson_write_flag YYJSON_WRITE_ALLOW_INVALID_UNICODE  = 1 << 5;
 
 
 /** Result code for JSON writer */


### PR DESCRIPTION
Add a new option `YYJSON_WRITE_ALLOW_INVALID_UNICODE` (optional via `YYJSON_DISABLE_NON_STANDARD`) to allow parsing invalid unicode data.

When `YYJSON_WRITE_ESCAPE_UNICODE` flag is set don't try to parse malformed unicode sequences, but copy them per-byte instead.