### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/doc/BuildAndTest.md
+++ b/doc/BuildAndTest.md
@@ -20,11 +20,13 @@ You can use some popular package managers to download and install yyjson, such a
 
 You can build and install yyjson using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
 
+```shell
 git clone https://github.com/Microsoft/vcpkg.git
 cd vcpkg
 ./bootstrap-vcpkg.sh  # ./bootstrap-vcpkg.bat for Powershell
 ./vcpkg integrate install
 ./vcpkg install yyjson
+```
 
 If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 

--- a/doc/BuildAndTest.md
+++ b/doc/BuildAndTest.md
@@ -16,6 +16,17 @@ yyjson has all features enabled by default, but you can trim out some of them by
 
 You can use some popular package managers to download and install yyjson, such as `vcpkg`, `conan`, and `xmake`. The yyjson package in these package managers is kept up to date by community contributors. If the version is out of date, please create an issue or pull request on their repository.
 
+## Use vcpkg
+
+You can build and install yyjson using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh  # ./bootstrap-vcpkg.bat for Powershell
+./vcpkg integrate install
+./vcpkg install yyjson
+
+If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
 # CMake
 


### PR DESCRIPTION
yyjson is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for yyjson and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build yyjson, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here](https://github.com/microsoft/vcpkg/blob/master/ports/yyjson/portfile.cmake) is what the port script looks like. We try to keep the library maintained as close as possible to the original library.