### PR TITLE
fix: qnx system compile error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,11 +35,15 @@ option(YYJSON_FORCE_32_BIT "Force 32-bit for tests (gcc/clang/icc)" OFF)
 
 # ------------------------------------------------------------------------------
 # Compilation options, see yyjson.h for more explanation
+option(YYJSON_ENABLE_QNX_SYSTEM "enable yyjson in qnx system" OFF)
 option(YYJSON_DISABLE_READER "Disable JSON reader" OFF)
 option(YYJSON_DISABLE_WRITER "Disable JSON writer" OFF)
 option(YYJSON_DISABLE_FAST_FP_CONV "Disable custom floating-point number conversion" OFF)
 option(YYJSON_DISABLE_NON_STANDARD "Disable non-standard JSON support" OFF)
 
+if(YYJSON_ENABLE_QNX_SYSTEM)
+    add_definitions(-DYYJSON_ENABLE_QNX_SYSTEM)
+endif()
 if(YYJSON_DISABLE_READER)
     add_definitions(-DYYJSON_DISABLE_READER)
 endif()

--- a/src/yyjson.c
+++ b/src/yyjson.c
@@ -4383,7 +4383,11 @@ skip_ascii_end:
      MSVC, Clang, ICC can generate expected instructions without this hint.
      */
 #if YYJSON_IS_REAL_GCC
-    __asm volatile("":"=m"(*src)::);
+    #ifdef YYJSON_ENABLE_QNX_SYSTEM
+        __asm volatile("":"=m"(*src):);
+    #else
+        __asm volatile("":"=m"(*src)::);
+    #endif
 #endif
     if (likely(*src == '"')) {
         val->tag = ((u64)(src - cur) << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
@@ -4499,9 +4503,15 @@ copy_ascii:
          });
      */
 #if YYJSON_IS_REAL_GCC
-#   define expr_jump(i) \
-    if (likely(!(char_is_ascii_stop(src[i])))) {} \
-    else { __asm volatile("":"=m"(src[i])::); goto copy_ascii_stop_##i; }
+    #ifdef YYJSON_ENABLE_QNX_SYSTEM
+        #   define expr_jump(i) \
+        if (likely(!(char_is_ascii_stop(src[i])))) {} \
+        else { __asm volatile("":"=m"(src[i]):); goto copy_ascii_stop_##i; }
+    #else
+        #   define expr_jump(i) \
+            if (likely(!(char_is_ascii_stop(src[i])))) {} \
+            else { __asm volatile("":"=m"(src[i])::); goto copy_ascii_stop_##i; }
+    #endif
 #else
 #   define expr_jump(i) \
     if (likely(!(char_is_ascii_stop(src[i])))) {} \

--- a/src/yyjson.h
+++ b/src/yyjson.h
@@ -30,6 +30,12 @@
  *============================================================================*/
 
 /*
+ Define as 1 to enable yyjson in qnx system.
+ */
+#ifndef YYJSON_ENABLE_QNX_SYSTEM
+#endif
+
+/*
  Define as 1 to disable JSON reader if you don't need to parse JSON.
  
  This will disable these functions at compile-time:


### PR DESCRIPTION
because of `__asm volatile("":"=m"(*src)::);`, yyjson can't compile successfully in QNX system.