### PR TITLE
Add Mutable yyjson val Detach Feature

### DIFF
--- a/test/test_json_mut_val.c
+++ b/test/test_json_mut_val.c
@@ -2083,7 +2083,7 @@ static void test_json_mut_equals_api(void) {
 }
 
 static void test_json_mut_detach_api(void) {
-    #if !YYJSON_DISABLE_READER
+#if !YYJSON_DISABLE_READER && !YYJSON_DISABLE_WRITER
     const char* json_str = "{\"a\":{\"b\":\"c\"}}";
     yyjson_doc *imut_doc = yyjson_read(json_str, strlen(json_str), 0);
     yyjson_mut_doc *old_doc = yyjson_doc_mut_copy(imut_doc, NULL);
@@ -2092,9 +2092,13 @@ static void test_json_mut_detach_api(void) {
     item = yyjson_mut_val_detach(old_doc, new_doc, item);
     yyjson_mut_doc_free(old_doc);
     yyjson_mut_doc_set_root(new_doc, item);
+
     char *new_json = yyjson_mut_write(new_doc, 0, NULL);
     validate_equals(new_json,"{\"b\":\"c\"}",true);
-    #endif
+    free(new_json);
+    yyjson_mut_doc_free(new_doc);
+    yyjson_doc_free(imut_doc);
+#endif
 }
 
 yy_test_case(test_json_mut_val) {

--- a/test/test_json_mut_val.c
+++ b/test/test_json_mut_val.c
@@ -2082,10 +2082,26 @@ static void test_json_mut_equals_api(void) {
 }]", true);
 }
 
+static void test_json_mut_detach_api(void) {
+    #if !YYJSON_DISABLE_READER
+    const char* json_str = "{\"a\":{\"b\":\"c\"}}";
+    yyjson_doc *imut_doc = yyjson_read(json_str, strlen(json_str), 0);
+    yyjson_mut_doc *old_doc = yyjson_doc_mut_copy(imut_doc, NULL);
+    yyjson_mut_doc *new_doc = yyjson_mut_doc_new(NULL);
+    yyjson_mut_val *item = yyjson_mut_doc_get_pointer(old_doc,"/a");
+    item = yyjson_mut_val_detach(old_doc, new_doc, item);
+    yyjson_mut_doc_free(old_doc);
+    yyjson_mut_doc_set_root(new_doc, item);
+    char *new_json = yyjson_mut_write(new_doc, 0, NULL);
+    validate_equals(new_json,"{\"b\":\"c\"}",true);
+    #endif
+}
+
 yy_test_case(test_json_mut_val) {
     test_json_mut_val_api();
     test_json_mut_arr_api();
     test_json_mut_obj_api();
     test_json_mut_doc_api();
     test_json_mut_equals_api();
+    test_json_mut_detach_api();
 }


### PR DESCRIPTION
In order to be able to manage the memory allocated by mut_val separately, I have made some changes to make it happen.

```c
struct yyjson_mut_val {
    uint64_t tag; /**< type, subtype and length */
    yyjson_val_uni uni; /**< payload */
    yyjson_mut_val *next; /**< the next value in circular linked list */
    yyjson_val_chunk *val_chunk;  // val memory chunk address
    yyjson_str_chunk *str_chunk;  // str memory chunk address
};
```
All changes are related to it. #106 
