### PR TITLE
Add functions to get type-specific values specified by JSON Pointer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Add support for Loongarch: #112
 - Add functions to support modifying memory pool size of `yyjson_mut_doc`.
 - Add convenience functions for creating iterator.
+- Add functions to get type-specific values specified by JSON Pointer.
 
 #### Changed
 - Change allocator's realloc function signature, add `old_size` parameter (just ignore the parameter if your allocator doesn't need it): #100

--- a/src/yyjson.h
+++ b/src/yyjson.h
@@ -6125,6 +6125,93 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_get_pointer(
     return yyjson_mut_get_pointer(doc ? doc->root : NULL, ptr);
 }
 
+/*==============================================================================
+ * JSON Value at Pointer API (Implementation)
+ *============================================================================*/
+
+/** Set provided `value` if the JSON Pointer (RFC 6901) exists and is type bool.
+    Returns true if value at `ptr` exists and is the correct type, otherwise false. */
+yyjson_api_inline bool yyjson_get_bool_pointer(
+    yyjson_doc *doc, const char *ptr, bool *value) {
+    yyjson_val *val = yyjson_doc_get_pointer(doc, ptr);
+    if (val && yyjson_is_bool(val)) {
+        *value = unsafe_yyjson_get_bool (val);
+        return true;
+    }
+    else {
+        return false;
+    }
+}
+
+/** Set provided `value` if the JSON Pointer (RFC 6901) exists and is type uint.
+    Returns true if value at `ptr` exists and is the correct type, otherwise false. */
+yyjson_api_inline bool yyjson_get_uint_pointer(
+    yyjson_doc *doc, const char *ptr, uint64_t *value) {
+    yyjson_val *val = yyjson_doc_get_pointer(doc, ptr);
+    if (val && yyjson_is_uint(val)) {
+        *value = unsafe_yyjson_get_uint(val);
+        return true;
+    }
+    else {
+        return false;
+    }
+}
+
+/** Set provided `value` if the JSON Pointer (RFC 6901) exists and is type sint.
+    Returns true if value at `ptr` exists and is the correct type, otherwise false. */
+yyjson_api_inline bool yyjson_get_sint_pointer(
+    yyjson_doc *doc, const char *ptr, int64_t *value) {
+    yyjson_val *val = yyjson_doc_get_pointer(doc, ptr);
+    if (val && yyjson_is_sint(val)) {
+        *value = unsafe_yyjson_get_sint(val);
+        return true;
+    }
+    else {
+        return false;
+    }
+}
+
+/** Set provided `value` if the JSON Pointer (RFC 6901) exists and is type real.
+    Returns true if value at `ptr` exists and is the correct type, otherwise false. */
+yyjson_api_inline bool yyjson_get_real_pointer(
+    yyjson_doc *doc, const char *ptr, double *value) {
+    yyjson_val *val = yyjson_doc_get_pointer(doc, ptr);
+    if (val && yyjson_is_real(val)) {
+        *value = unsafe_yyjson_get_real(val);
+        return true;
+    }
+    else {
+        return false;
+    }
+}
+
+/** Set provided `value` if the JSON Pointer (RFC 6901) exists and is type sint, uint or real.
+    Returns true if value at `ptr` exists and is the correct type, otherwise false. */
+yyjson_api_inline bool yyjson_get_num_pointer(
+    yyjson_doc *doc, const char *ptr, double *value) {
+    yyjson_val *val = yyjson_doc_get_pointer(doc, ptr);
+    if (val && yyjson_is_num(val)) {
+        *value = unsafe_yyjson_get_num(val);
+        return true;
+    }
+    else {
+        return false;
+    }
+}
+
+/** Set provided `value` if the JSON Pointer (RFC 6901) exists and is type string.
+    Returns true if value at `ptr` exists and is the correct type, otherwise false. */
+yyjson_api_inline bool yyjson_get_str_pointer(
+    yyjson_doc *doc, const char *ptr, const char **value) {
+    yyjson_val *val = yyjson_doc_get_pointer(doc, ptr);
+    if (val && yyjson_is_str(val)) {
+        *value = unsafe_yyjson_get_str(val);
+        return true;
+    }
+    else {
+        return false;
+    }
+}
 
 
 /*==============================================================================

--- a/src/yyjson.h
+++ b/src/yyjson.h
@@ -6134,7 +6134,7 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_get_pointer(
 yyjson_api_inline bool yyjson_get_bool_pointer(
     yyjson_doc *doc, const char *ptr, bool *value) {
     yyjson_val *val = yyjson_doc_get_pointer(doc, ptr);
-    if (val && yyjson_is_bool(val)) {
+    if (value && yyjson_is_bool(val)) {
         *value = unsafe_yyjson_get_bool (val);
         return true;
     }
@@ -6148,7 +6148,7 @@ yyjson_api_inline bool yyjson_get_bool_pointer(
 yyjson_api_inline bool yyjson_get_uint_pointer(
     yyjson_doc *doc, const char *ptr, uint64_t *value) {
     yyjson_val *val = yyjson_doc_get_pointer(doc, ptr);
-    if (val && yyjson_is_uint(val)) {
+    if (value && yyjson_is_uint(val)) {
         *value = unsafe_yyjson_get_uint(val);
         return true;
     }
@@ -6162,7 +6162,7 @@ yyjson_api_inline bool yyjson_get_uint_pointer(
 yyjson_api_inline bool yyjson_get_sint_pointer(
     yyjson_doc *doc, const char *ptr, int64_t *value) {
     yyjson_val *val = yyjson_doc_get_pointer(doc, ptr);
-    if (val && yyjson_is_sint(val)) {
+    if (value && yyjson_is_sint(val)) {
         *value = unsafe_yyjson_get_sint(val);
         return true;
     }
@@ -6176,7 +6176,7 @@ yyjson_api_inline bool yyjson_get_sint_pointer(
 yyjson_api_inline bool yyjson_get_real_pointer(
     yyjson_doc *doc, const char *ptr, double *value) {
     yyjson_val *val = yyjson_doc_get_pointer(doc, ptr);
-    if (val && yyjson_is_real(val)) {
+    if (value && yyjson_is_real(val)) {
         *value = unsafe_yyjson_get_real(val);
         return true;
     }
@@ -6190,7 +6190,7 @@ yyjson_api_inline bool yyjson_get_real_pointer(
 yyjson_api_inline bool yyjson_get_num_pointer(
     yyjson_doc *doc, const char *ptr, double *value) {
     yyjson_val *val = yyjson_doc_get_pointer(doc, ptr);
-    if (val && yyjson_is_num(val)) {
+    if (value && yyjson_is_num(val)) {
         *value = unsafe_yyjson_get_num(val);
         return true;
     }
@@ -6204,7 +6204,7 @@ yyjson_api_inline bool yyjson_get_num_pointer(
 yyjson_api_inline bool yyjson_get_str_pointer(
     yyjson_doc *doc, const char *ptr, const char **value) {
     yyjson_val *val = yyjson_doc_get_pointer(doc, ptr);
-    if (val && yyjson_is_str(val)) {
+    if (value && yyjson_is_str(val)) {
         *value = unsafe_yyjson_get_str(val);
         return true;
     }

--- a/test/test_json_pointer.c
+++ b/test/test_json_pointer.c
@@ -190,12 +190,51 @@ static void validate_spec(void) {
     yyjson_mut_doc_free(mdoc);
 }
 
+static void validate_get_type(void) {
+    const char *json = "{ \
+        \"answer\": {\"to\": {\"life\": 42}}, \
+        \"true\": true, \
+        \"-1\": -1, \
+        \"zero\": 0, \
+        \"pi\": 3.14159, \
+        \"pistr\": \"3.14159\" \
+    }";
+
+    bool bool_value;
+    double real_value;
+    int64_t sint_value;
+    uint64_t uint_value;
+    const char *string_value;
+
+    yyjson_doc *doc = yyjson_read(json, strlen(json), 0);
+
+    // successful gets
+    yy_assert(yyjson_get_bool_pointer(doc, "/true", &bool_value) == true && bool_value == true);
+    yy_assert(yyjson_get_uint_pointer(doc, "/answer/to/life", &uint_value) == true && uint_value == 42);
+    yy_assert(yyjson_get_sint_pointer(doc, "/-1", &sint_value) == true && sint_value == -1);
+    yy_assert(yyjson_get_real_pointer(doc, "/pi", &real_value) == true && real_value == (double)3.14159);
+    yy_assert(yyjson_get_num_pointer(doc, "/-1", &real_value) == true && real_value == (double)-1.0);
+    yy_assert(yyjson_get_num_pointer(doc, "/zero", &real_value) == true && real_value == (double)0.0);
+    yy_assert(yyjson_get_num_pointer(doc, "/answer/to/life", &real_value) == true && real_value == (double)42.0);
+    yy_assert(yyjson_get_num_pointer(doc, "/pi", &real_value) == true && real_value == (double)3.14159);
+    yy_assert(yyjson_get_str_pointer(doc, "/pistr", &string_value) == true && strcmp(string_value, "3.14159") == 0);
+
+    // unsuccessful gets
+    yy_assert(yyjson_get_uint_pointer(doc, "/-1", &uint_value) == false);  // wrong type
+    yy_assert(yyjson_get_num_pointer(doc, "/pistr", &real_value) == false);  // wrong type
+    yy_assert(yyjson_get_str_pointer(doc, "/answer/to", &string_value) == false);  // wrong type
+    yy_assert(yyjson_get_real_pointer(doc, "/nosuch", &real_value) == false); // Does not exist
+
+    yyjson_doc_free(doc);
+}
+
 yy_test_case(test_json_pointer) {
     validate_num();
     validate_long_str();
     validate_long_idx();
     validate_err();
     validate_spec();
+    validate_get_type();
 }
 
 #else


### PR DESCRIPTION
This PR adds the following convenience functions that get a value from `yyjson_doc` as specified by a JSON Pointer:

```
yyjson_get_bool_pointer()
yyjson_get_uint_pointer()
yyjson_get_sint_pointer()
yyjson_get_real_pointer()
yyjson_get_num_pointer()
yyjson_get_str_pointer()
```

Additionally, these functions allow the caller to disambiguate non-existing or type-mismatches from actual values of `false`, `0` and `0.0`, which is ambiguous using by their non-pointer variants (`yyget_get_bool()`, `yyjson_get_uint()`,...).

Tests included.
