### PR TITLE
Convert yyjson_get_TYPE_pointer() routines to accept `yyjson_val`

### DIFF
--- a/src/yyjson.h
+++ b/src/yyjson.h
@@ -6136,8 +6136,8 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_get_pointer(
  Returns true if value at `ptr` exists and is the correct type, otherwise false.
  */
 yyjson_api_inline bool yyjson_get_bool_pointer(
-    yyjson_doc *doc, const char *ptr, bool *value) {
-    yyjson_val *val = yyjson_doc_get_pointer(doc, ptr);
+    yyjson_val *root, const char *ptr, bool *value) {
+    yyjson_val *val = yyjson_get_pointer(root, ptr);
     if (value && yyjson_is_bool(val)) {
         *value = unsafe_yyjson_get_bool (val);
         return true;
@@ -6151,8 +6151,8 @@ yyjson_api_inline bool yyjson_get_bool_pointer(
  Returns true if value at `ptr` exists and is the correct type, otherwise false.
  */
 yyjson_api_inline bool yyjson_get_uint_pointer(
-    yyjson_doc *doc, const char *ptr, uint64_t *value) {
-    yyjson_val *val = yyjson_doc_get_pointer(doc, ptr);
+    yyjson_val *root, const char *ptr, uint64_t *value) {
+    yyjson_val *val = yyjson_get_pointer(root, ptr);
     if (value && yyjson_is_uint(val)) {
         *value = unsafe_yyjson_get_uint(val);
         return true;
@@ -6166,8 +6166,8 @@ yyjson_api_inline bool yyjson_get_uint_pointer(
  Returns true if value at `ptr` exists and is the correct type, otherwise false.
  */
 yyjson_api_inline bool yyjson_get_sint_pointer(
-    yyjson_doc *doc, const char *ptr, int64_t *value) {
-    yyjson_val *val = yyjson_doc_get_pointer(doc, ptr);
+    yyjson_val *root, const char *ptr, int64_t *value) {
+    yyjson_val *val = yyjson_get_pointer(root, ptr);
     if (value && yyjson_is_sint(val)) {
         *value = unsafe_yyjson_get_sint(val);
         return true;
@@ -6181,8 +6181,8 @@ yyjson_api_inline bool yyjson_get_sint_pointer(
  Returns true if value at `ptr` exists and is the correct type, otherwise false.
  */
 yyjson_api_inline bool yyjson_get_real_pointer(
-    yyjson_doc *doc, const char *ptr, double *value) {
-    yyjson_val *val = yyjson_doc_get_pointer(doc, ptr);
+    yyjson_val *root, const char *ptr, double *value) {
+    yyjson_val *val = yyjson_get_pointer(root, ptr);
     if (value && yyjson_is_real(val)) {
         *value = unsafe_yyjson_get_real(val);
         return true;
@@ -6197,8 +6197,8 @@ yyjson_api_inline bool yyjson_get_real_pointer(
  Returns true if value at `ptr` exists and is the correct type, otherwise false.
  */
 yyjson_api_inline bool yyjson_get_num_pointer(
-    yyjson_doc *doc, const char *ptr, double *value) {
-    yyjson_val *val = yyjson_doc_get_pointer(doc, ptr);
+    yyjson_val *root, const char *ptr, double *value) {
+    yyjson_val *val = yyjson_get_pointer(root, ptr);
     if (value && yyjson_is_num(val)) {
         *value = unsafe_yyjson_get_num(val);
         return true;
@@ -6212,8 +6212,8 @@ yyjson_api_inline bool yyjson_get_num_pointer(
  Returns true if value at `ptr` exists and is the correct type, otherwise false.
  */
 yyjson_api_inline bool yyjson_get_str_pointer(
-    yyjson_doc *doc, const char *ptr, const char **value) {
-    yyjson_val *val = yyjson_doc_get_pointer(doc, ptr);
+    yyjson_val *root, const char *ptr, const char **value) {
+    yyjson_val *val = yyjson_get_pointer(root, ptr);
     if (value && yyjson_is_str(val)) {
         *value = unsafe_yyjson_get_str(val);
         return true;

--- a/test/test_json_pointer.c
+++ b/test/test_json_pointer.c
@@ -207,23 +207,24 @@ static void validate_get_type(void) {
     const char *string_value;
 
     yyjson_doc *doc = yyjson_read(json, strlen(json), 0);
+    yyjson_val *root = yyjson_doc_get_root (doc);
 
     // successful gets
-    yy_assert(yyjson_get_bool_pointer(doc, "/true", &bool_value) == true && bool_value == true);
-    yy_assert(yyjson_get_uint_pointer(doc, "/answer/to/life", &uint_value) == true && uint_value == 42);
-    yy_assert(yyjson_get_sint_pointer(doc, "/-1", &sint_value) == true && sint_value == -1);
-    yy_assert(yyjson_get_real_pointer(doc, "/pi", &real_value) == true && real_value == (double)3.14159);
-    yy_assert(yyjson_get_num_pointer(doc, "/-1", &real_value) == true && real_value == (double)-1.0);
-    yy_assert(yyjson_get_num_pointer(doc, "/zero", &real_value) == true && real_value == (double)0.0);
-    yy_assert(yyjson_get_num_pointer(doc, "/answer/to/life", &real_value) == true && real_value == (double)42.0);
-    yy_assert(yyjson_get_num_pointer(doc, "/pi", &real_value) == true && real_value == (double)3.14159);
-    yy_assert(yyjson_get_str_pointer(doc, "/pistr", &string_value) == true && strcmp(string_value, "3.14159") == 0);
+    yy_assert(yyjson_get_bool_pointer(root, "/true", &bool_value) == true && bool_value == true);
+    yy_assert(yyjson_get_uint_pointer(root, "/answer/to/life", &uint_value) == true && uint_value == 42);
+    yy_assert(yyjson_get_sint_pointer(root, "/-1", &sint_value) == true && sint_value == -1);
+    yy_assert(yyjson_get_real_pointer(root, "/pi", &real_value) == true && real_value == (double)3.14159);
+    yy_assert(yyjson_get_num_pointer(root, "/-1", &real_value) == true && real_value == (double)-1.0);
+    yy_assert(yyjson_get_num_pointer(root, "/zero", &real_value) == true && real_value == (double)0.0);
+    yy_assert(yyjson_get_num_pointer(root, "/answer/to/life", &real_value) == true && real_value == (double)42.0);
+    yy_assert(yyjson_get_num_pointer(root, "/pi", &real_value) == true && real_value == (double)3.14159);
+    yy_assert(yyjson_get_str_pointer(root, "/pistr", &string_value) == true && strcmp(string_value, "3.14159") == 0);
 
     // unsuccessful gets
-    yy_assert(yyjson_get_uint_pointer(doc, "/-1", &uint_value) == false);  // wrong type
-    yy_assert(yyjson_get_num_pointer(doc, "/pistr", &real_value) == false);  // wrong type
-    yy_assert(yyjson_get_str_pointer(doc, "/answer/to", &string_value) == false);  // wrong type
-    yy_assert(yyjson_get_real_pointer(doc, "/nosuch", &real_value) == false); // Does not exist
+    yy_assert(yyjson_get_uint_pointer(root, "/-1", &uint_value) == false);  // wrong type
+    yy_assert(yyjson_get_num_pointer(root, "/pistr", &real_value) == false);  // wrong type
+    yy_assert(yyjson_get_str_pointer(root, "/answer/to", &string_value) == false);  // wrong type
+    yy_assert(yyjson_get_real_pointer(root, "/nosuch", &real_value) == false); // Does not exist
 
     yyjson_doc_free(doc);
 }


### PR DESCRIPTION
In #116 the functions do not follow the API naming conventions.  Specifically, they accepted `yyjson_doc` but did not include `doc` in their name.

On further consideration, these functions would be more flexible if they accepted `yyjson_val` instead of `yyjson_doc` as one can always use `yyjson_doc_get_root()` and therefore support more use cases.

This PR changes the functions to accept `yyjson_val` instead of `yyjson_doc`.