### PR TITLE
Add new keys at end of object with Merge Patch

### DIFF
--- a/src/yyjson.c
+++ b/src/yyjson.c
@@ -1861,6 +1861,21 @@ yyjson_api yyjson_mut_val *yyjson_merge_patch(yyjson_mut_doc *doc,
         orig->uni = builder->uni;
     }
     
+    /* If orig is contributing, copy any items not modified by the patch */
+    if (orig != &local_orig)
+    {
+        yyjson_obj_foreach(orig, idx, max, key, orig_val) {
+            patch_val = yyjson_obj_getn(patch,
+                                        unsafe_yyjson_get_str(key),
+                                        unsafe_yyjson_get_len(key));
+            if (!patch_val) {
+                mut_key = yyjson_val_mut_copy(doc, key);
+                mut_val = yyjson_val_mut_copy(doc, orig_val);
+                if (!yyjson_mut_obj_add(builder, mut_key, mut_val)) return NULL;
+            }
+        }
+    }
+
     /* Merge items modified by the patch. */
     yyjson_obj_foreach(patch, idx, max, key, patch_val) {
         /* null indicates the field is removed. */
@@ -1873,23 +1888,6 @@ yyjson_api yyjson_mut_val *yyjson_merge_patch(yyjson_mut_doc *doc,
                                    unsafe_yyjson_get_len(key));
         merged_val = yyjson_merge_patch(doc, orig_val, patch_val);
         if (!yyjson_mut_obj_add(builder, mut_key, merged_val)) return NULL;
-    }
-    
-    /* Exit early, if orig is not contributing to the final result. */
-    if (orig == &local_orig) {
-        return builder;
-    }
-    
-    /* Copy over any items that weren't modified by the patch. */
-    yyjson_obj_foreach(orig, idx, max, key, orig_val) {
-        patch_val = yyjson_obj_getn(patch,
-                                    unsafe_yyjson_get_str(key),
-                                    unsafe_yyjson_get_len(key));
-        if (!patch_val) {
-            mut_key = yyjson_val_mut_copy(doc, key);
-            mut_val = yyjson_val_mut_copy(doc, orig_val);
-            if (!yyjson_mut_obj_add(builder, mut_key, mut_val)) return NULL;
-        }
     }
     
     return builder;
@@ -1915,6 +1913,21 @@ yyjson_api yyjson_mut_val *yyjson_mut_merge_patch(yyjson_mut_doc *doc,
         orig->uni = builder->uni;
     }
     
+    /* If orig is contributing, copy any items not modified by the patch */
+    if (orig != &local_orig)
+    {
+        yyjson_mut_obj_foreach(orig, idx, max, key, orig_val) {
+            patch_val = yyjson_mut_obj_getn(patch,
+                                            unsafe_yyjson_get_str(key),
+                                            unsafe_yyjson_get_len(key));
+            if (!patch_val) {
+                mut_key = yyjson_mut_val_mut_copy(doc, key);
+                mut_val = yyjson_mut_val_mut_copy(doc, orig_val);
+                if (!yyjson_mut_obj_add(builder, mut_key, mut_val)) return NULL;
+            }
+        }
+    }
+
     /* Merge items modified by the patch. */
     yyjson_mut_obj_foreach(patch, idx, max, key, patch_val) {
         /* null indicates the field is removed. */
@@ -1927,23 +1940,6 @@ yyjson_api yyjson_mut_val *yyjson_mut_merge_patch(yyjson_mut_doc *doc,
                                        unsafe_yyjson_get_len(key));
         merged_val = yyjson_mut_merge_patch(doc, orig_val, patch_val);
         if (!yyjson_mut_obj_add(builder, mut_key, merged_val)) return NULL;
-    }
-    
-    /* Exit early, if orig is not contributing to the final result. */
-    if (orig == &local_orig) {
-        return builder;
-    }
-    
-    /* Copy over any items that weren't modified by the patch. */
-    yyjson_mut_obj_foreach(orig, idx, max, key, orig_val) {
-        patch_val = yyjson_mut_obj_getn(patch,
-                                        unsafe_yyjson_get_str(key),
-                                        unsafe_yyjson_get_len(key));
-        if (!patch_val) {
-            mut_key = yyjson_mut_val_mut_copy(doc, key);
-            mut_val = yyjson_mut_val_mut_copy(doc, orig_val);
-            if (!yyjson_mut_obj_add(builder, mut_key, mut_val)) return NULL;
-        }
     }
     
     return builder;


### PR DESCRIPTION
Modify the Merge Patch logic to insert new additions to an object at the end of the object.

While technically a JSON object is an "unordered set of name/value pairs", it is nice to be able to control the order in some edge cases (my case is matching a specification for maximum clarity).  Further, it is logical that when adding new key/value pairs to an object that they would be added at the end, which is nicely done by `yyjson_mut_obj_add()` and friends.

The logic of `yyjson_merge_patch()` and `yyjson_mut_merge_patch()` lead to additions to objects going before the key/value pairs already existing in the object that are unmodified by the patch.

This PR inverts the order of adding values to the new structure such that modified values are added after unmodified values.

I initially tried replacing:
```C
if (!yyjson_mut_obj_add(builder, mut_key, mut_val)) return NULL;
```
with
```C
if (!yyjson_mut_obj_insert(builder, mut_key, mut_val, 0)) return NULL;
```
to add `orig` elements to the new structure explicitly at the beginning but got some unexpected results.  I do not understand the link data structure well enough to figure out why that did not work.  So I just swapped the order of additions.

It's not perfect, the root key of any value modified in a nested object structure will move to the bottom (as opposed to staying in place), but at least this is an improvement if one wishes additions to be at the end of an object.

FWIW, this now makes the example test cases in [RFC 7386](https://www.rfc-editor.org/rfc/rfc7386#appendix-A) result in a matching serialized form in terms of order.  Specifically this case:
```
   ORIGINAL        PATCH            RESULT
   ------------------------------------------
...

   {"a":"b"}       {"b":"c"}       {"a":"b",
                                    "b":"c"}
```




