### PR TITLE
Add a short section in the README.md for bindings and projects.

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,22 @@ The pre-generated Doxygen HTML for the release version can be viewed here:
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/yyjson.svg)](https://repology.org/project/yyjson/versions)
 
+# Built With yyjson
+
+A non-exhaustive list of projects that expose yyjson to other languages or
+use yyjson internally for a major feature. If you have a project that uses
+yyjson, feel free to open a PR to add it to this list.
+
+| Project        | Language | Description                                                  |
+|----------------|----------|--------------------------------------------------------------|
+| [py_yyjson][]  | Python   | Python bindings for yyjson                                   |
+| [orjson][]     | Python   | JSON library for Python with an optional yyjson backend      |
+| [cpp-yyjson][] | C++      | C++ JSON library with a yyjson backend                       |
+| [yyjsonr][]    | R        | R binding for yyjson                                         |
+| [Anada][]      | Swift    | JSON model decoding based on yyjson                          |
+| [duckdb][]     | C++      | DuckDB is an in-process SQL OLAP Database Management System  |
+
+
 # TODO
 * [x] Add documentation page.
 * [x] Add GitHub workflow for CI and codecov.
@@ -220,3 +236,11 @@ The pre-generated Doxygen HTML for the release version can be viewed here:
 
 # License
 This project is released under the MIT license.
+
+
+[py_yyjson]: https://github.com/tktech/py_yyjson
+[orjson]: https://github.com/ijl/orjson
+[cpp-yyjson]: https://github.com/yosh-matsuda/cpp-yyjson
+[yyjsonr]: https://github.com/coolbutuseless/yyjsonr
+[Anada]: https://github.com/nixzhu/Ananda
+[duckdb]: https://github.com/duckdb/duckdb


### PR DESCRIPTION
Add a short section in the README.md for bindings and projects that use yyjson as a major feature. Closes #137.

There's definitely a lot more projects using yyjson than this. The dependency graph under https://github.com/ibireme/yyjson/network/dependents doesn't  seem to work  and GitHub's code search makes it hard to find _unique_ results, so it's mostly just giving the same 2-3 repos over and over again.

Feel free to re-order. I put my own project first, my excuse is that it's the oldest by something like 3 years :)