### PR TITLE
Don't overwrite CMake configuration types if yyjson is used as a dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,12 +9,14 @@ project(yyjson VERSION 0.8.0 LANGUAGES C)
 
 # ------------------------------------------------------------------------------
 # Build Type
-if(XCODE OR MSVC)
-    set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "" FORCE)
-endif()
-if(NOT CMAKE_BUILD_TYPE)
-    message(STATUS "No build type selected, default to: Release")
-    set(CMAKE_BUILD_TYPE Release)
+if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    if(XCODE OR MSVC)
+        set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "" FORCE)
+    endif()
+    if(NOT CMAKE_BUILD_TYPE)
+        message(STATUS "No build type selected, default to: Release")
+        set(CMAKE_BUILD_TYPE Release)
+    endif()
 endif()
 
 


### PR DESCRIPTION
Hi!
I've noticed that the CMake script overwrites the value of `CMAKE_CONFIGURATION_TYPES` for multi-config CMake generators. That effectively locks the configuration list to Debug and Release for CMake projects that add `yyjson` as a dependency with `add_subdirectory` (either directly, with `FetchContent` or by any other means). In my case I would like to keep the default value of `CMAKE_CONFIGURATION_TYPES` which has more configurations

The fix is to avoid changing `CMAKE_BUILD_TYPE` or `CMAKE_CONFIGURATION_TYPES` if yyjson is not the root CMake project. As far as I can see those variables are meant to be set only when building the library itself (but let me know if that's not correct)

Tested by generating and compiling `yyjson` with Visual Studio on Windows, both Debug and Release (Visual Studio 2022, CMake 3.25.1)

Let me know if you have another solution in mind