### PR TITLE
Include reflect-cpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,15 +213,15 @@ A non-exhaustive list of projects that expose yyjson to other languages or
 use yyjson internally for a major feature. If you have a project that uses
 yyjson, feel free to open a PR to add it to this list.
 
-| Project         | Language | Description                                                                                            |
-|-----------------|----------|--------------------------------------------------------------------------------------------------------|
-| [py_yyjson][]   | Python   | Python bindings for yyjson                                                                             |
-| [orjson][]      | Python   | JSON library for Python with an optional yyjson backend                                                |
-| [cpp-yyjson][]  | C++      | C++ JSON library with a yyjson backend                                                                 |
-| [reflect-cpp][] | C++      | C++ library for serialization through reflection, includes automated field name retrieval from structs |
-| [yyjsonr][]     | R        | R binding for yyjson                                                                                   |
-| [Ananda][]      | Swift    | JSON model decoding based on yyjson                                                                    |
-| [duckdb][]      | C++      | DuckDB is an in-process SQL OLAP Database Management System                                            |
+| Project         | Language | Description                                                                       |
+|-----------------|----------|-----------------------------------------------------------------------------------|
+| [py_yyjson][]   | Python   | Python bindings for yyjson                                                        |
+| [orjson][]      | Python   | JSON library for Python with an optional yyjson backend                           |
+| [cpp-yyjson][]  | C++      | C++ JSON library with a yyjson backend                                            |
+| [reflect-cpp][] | C++      | C++ library for serialization through automated field name retrieval from structs |
+| [yyjsonr][]     | R        | R binding for yyjson                                                              |
+| [Ananda][]      | Swift    | JSON model decoding based on yyjson                                               |
+| [duckdb][]      | C++      | DuckDB is an in-process SQL OLAP Database Management System                       |
 
 
 # TODO

--- a/README.md
+++ b/README.md
@@ -213,14 +213,15 @@ A non-exhaustive list of projects that expose yyjson to other languages or
 use yyjson internally for a major feature. If you have a project that uses
 yyjson, feel free to open a PR to add it to this list.
 
-| Project        | Language | Description                                                  |
-|----------------|----------|--------------------------------------------------------------|
-| [py_yyjson][]  | Python   | Python bindings for yyjson                                   |
-| [orjson][]     | Python   | JSON library for Python with an optional yyjson backend      |
-| [cpp-yyjson][] | C++      | C++ JSON library with a yyjson backend                       |
-| [yyjsonr][]    | R        | R binding for yyjson                                         |
-| [Ananda][]     | Swift    | JSON model decoding based on yyjson                          |
-| [duckdb][]     | C++      | DuckDB is an in-process SQL OLAP Database Management System  |
+| Project         | Language | Description                                                                                            |
+|-----------------|----------|--------------------------------------------------------------------------------------------------------|
+| [py_yyjson][]   | Python   | Python bindings for yyjson                                                                             |
+| [orjson][]      | Python   | JSON library for Python with an optional yyjson backend                                                |
+| [cpp-yyjson][]  | C++      | C++ JSON library with a yyjson backend                                                                 |
+| [reflect-cpp][] | C++      | C++ library for serialization through reflection, includes automated field name retrieval from structs |
+| [yyjsonr][]     | R        | R binding for yyjson                                                                                   |
+| [Ananda][]      | Swift    | JSON model decoding based on yyjson                                                                    |
+| [duckdb][]      | C++      | DuckDB is an in-process SQL OLAP Database Management System                                            |
 
 
 # TODO
@@ -241,6 +242,7 @@ This project is released under the MIT license.
 [py_yyjson]: https://github.com/tktech/py_yyjson
 [orjson]: https://github.com/ijl/orjson
 [cpp-yyjson]: https://github.com/yosh-matsuda/cpp-yyjson
+[reflect-cpp]: https://github.com/getml/reflect-cpp
 [yyjsonr]: https://github.com/coolbutuseless/yyjsonr
 [Ananda]: https://github.com/nixzhu/Ananda
 [duckdb]: https://github.com/duckdb/duckdb


### PR DESCRIPTION
Hi mate,

thanks for your great work!

We are developing a C++ library for serialization, deserialization and validation through reflection. It includes things like automatic field name retrieval from structs and enums.

The JSON part is based on YYJSON, so your work is front and center for what we do here.

So I wonder whether you could include it in your "build with YYJSON" section.