### PR TITLE
Correct the error in the comment for unsafe_yyjson_mut_strncpy

### DIFF
--- a/src/yyjson.h
+++ b/src/yyjson.h
@@ -3699,7 +3699,7 @@ yyjson_api_inline bool yyjson_mut_obj_add_strcpy(yyjson_mut_doc *doc,
     The `len` should be the length of the `val`, in bytes.
     This function allows duplicated key in one object.
     
-    @warning The key/value strings are not copied, you should keep these strings
+    @warning The key strings are not copied, you should keep these strings
         unmodified for the lifetime of this JSON document. */
 yyjson_api_inline bool yyjson_mut_obj_add_strncpy(yyjson_mut_doc *doc,
                                                   yyjson_mut_val *obj,


### PR DESCRIPTION
Similar to `yyjson_mut_obj_add_strcpy`, in fact, the `val` & `len` in `yyjson_mut_obj_add_strncpy` have already been assigned values 
and do not need to have their lifetimes guaranteed.
https://github.com/ibireme/yyjson/blob/0eca326fe57aeeb866e6f04c9ef9ea9f8343157e/src/yyjson.h#L6963-L6974
The call to `unsafe_yyjson_mut_strncpy` in the above code also proves this point.