### PR TITLE
Parameter of get_enc_table_with_flag is json_read_flag, should be json_write_flag

### DIFF
--- a/src/yyjson.c
+++ b/src/yyjson.c
@@ -7835,7 +7835,7 @@ static const u8 esc_single_char_table[512] = {
 
 /** Returns the encode table with options. */
 static_inline const char_enc_type *get_enc_table_with_flag(
-    yyjson_read_flag flg) {
+    yyjson_write_flag flg) {
     if (has_write_flag(ESCAPE_UNICODE)) {
         if (has_write_flag(ESCAPE_SLASHES)) {
             return enc_table_esc_slash;


### PR DESCRIPTION
`json_read_flag` and `json_write_flag` are both typedef'ed to `uint32_t`, but for good sense, the parameter in `get_enc_table_with_flag` should be `json_write_flag`, not `json_read_flag` 