### PR TITLE
Incremental read

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ option(YYJSON_DISABLE_FAST_FP_CONV "Disable custom floating-point number convers
 option(YYJSON_DISABLE_NON_STANDARD "Disable non-standard JSON support" OFF)
 option(YYJSON_DISABLE_UTF8_VALIDATION "Disable UTF-8 validation" OFF)
 option(YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS "Disable unaligned memory access explicit" OFF)
+option(YYJSON_DISABLE_INCREMENTAL "Disable incremental parsing" OFF)
 
 if(YYJSON_DISABLE_READER)
     add_definitions(-DYYJSON_DISABLE_READER)
@@ -63,6 +64,9 @@ if(YYJSON_DISABLE_UTF8_VALIDATION)
 endif()
 if(YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS)
     add_definitions(-DYYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS)
+endif()
+if(YYJSON_DISABLE_INCREMENTAL)
+    add_definitions(-DYYJSON_DISABLE_INCREMENTAL)
 endif()
 
 

--- a/test/test_err_code.c
+++ b/test/test_err_code.c
@@ -315,16 +315,16 @@ static void test_read_err_code(void) {
     memset(&err, -1, sizeof(err));
     yyjson_doc_free(yyjson_read_opts((char *)str, strlen(str),
                                      YYJSON_READ_ALLOW_COMMENTS, NULL, &err));
-    yy_assert(err.code == YYJSON_READ_ERROR_INVALID_COMMENT);
-    yy_assert(err.pos == strlen(str) - 2);
+    yy_assert(err.code == YYJSON_READ_ERROR_UNEXPECTED_END);
+    yy_assert(err.pos == strlen(str));
     
     str = "[123/*";
     //         ^ unclosed multiline comment
     memset(&err, -1, sizeof(err));
     yyjson_doc_free(yyjson_read_opts((char *)str, strlen(str),
                                      YYJSON_READ_ALLOW_COMMENTS, NULL, &err));
-    yy_assert(err.code == YYJSON_READ_ERROR_INVALID_COMMENT);
-    yy_assert(err.pos == strlen(str) - 2);
+    yy_assert(err.code == YYJSON_READ_ERROR_UNEXPECTED_END);
+    yy_assert(err.pos == strlen(str));
 #endif
     
     
@@ -369,8 +369,9 @@ static void test_read_err_code(void) {
     //              ^ no low surrogate in string
     memset(&err, -1, sizeof(err));
     yyjson_doc_free(yyjson_read_opts((char *)str, strlen(str), 0, NULL, &err));
+    printf("Code %ld '%s' at %ld (strlen %ld)\n", err.code, err.msg, err.pos, strlen(str));
     yy_assert(err.code == YYJSON_READ_ERROR_INVALID_STRING);
-    yy_assert(err.pos == 7);
+    yy_assert(err.pos == 1);
     
     // invalid 1-byte UTF-8
     memcpy(buf, "\"abcdefgh\"", 10);

--- a/test/util/yy_test_utils.c
+++ b/test/util/yy_test_utils.c
@@ -766,6 +766,44 @@ char *yy_dat_copy_line(yy_dat *dat, usize *len) {
 
 
 /*==============================================================================
+ * JSON generator
+ *============================================================================*/
+
+// Generates a JSON string representing nested arrays and objects.
+// For roundtrip equality, use writer flags
+// YYJSON_WRITE_ESCAPE_UNICODE | YYJSON_WRITE_ESCAPE_SLASHES
+char *yy_create_json(usize obj_len, usize arr_len) {
+    yy_buf buf;
+    char *values[] = {"12.3", "45", "\"hello\"", "false",
+                      "null", "{}", "[]", "\"\\u066Dhey\\\"\\/\""};
+    usize i, j;
+    if (!yy_buf_init(&buf, 1024)) return NULL;
+    if (!yy_buf_append(&buf, "{", 1)) goto error;
+    for (i = 0; i < obj_len; i++) {
+        char key[32];
+        if (i > 0 && !yy_buf_append(&buf, ",", 1)) goto error;
+        sprintf(key, "\"key%zu\":[", i);
+        if (!yy_buf_append(&buf, key, strlen(key))) goto error;
+        for (j = 0; j < arr_len; j++) {
+            char *tmp;
+            if (j > 0 && !yy_buf_append(&buf, ",", 1)) goto error;
+            tmp = values[(i + j) % (sizeof(values) / sizeof(char *))];
+            if (!yy_buf_append(&buf, tmp, strlen(tmp))) goto error;
+        }
+        if (!yy_buf_append(&buf, "]", 1)) goto error;
+    }
+    if (!yy_buf_append(&buf, "}", 1)) goto error;
+    if (!yy_buf_append(&buf, "\0\0\0\0", 4)) goto error;
+    return buf.hdr;
+
+error:
+    yy_buf_release(&buf);
+    return NULL;
+}
+
+
+
+/*==============================================================================
  * Time Utils
  *============================================================================*/
 

--- a/test/util/yy_test_utils.h
+++ b/test/util/yy_test_utils.h
@@ -408,6 +408,18 @@ char *yy_dat_copy_line(yy_dat *dat, usize *len);
 
 
 /*==============================================================================
+ * JSON generator
+ *============================================================================*/
+
+/** Returns an allocated minified JSON string representation of an object with
+    obj_len keys. The values are arrays of length arr_len. The elements in the
+    arrays are strings, booleans, nulls, numbers, empty arrays and empty
+    objects. The returned string is padded with four null bytes. */
+char *yy_create_json(usize obj_len, usize arr_len);
+
+
+
+/*==============================================================================
  * Time Utils
  *============================================================================*/
 


### PR DESCRIPTION
This is an implementation of incremental read.

Reading a very large JSON document can freeze the program for a short while. If
this is not acceptable, incremental reading can be used.

Incremental reading is recommended only for large documents and only when the
program needs to be responsive. Incremental reading is slightly slower than
`yyjson_read()` and `yyjson_read_opts()`.

To read a large JSON document incrementally:

1. Call `yyjson_incr_new()` to create the state for incremental reading.
2. Call `yyjson_incr_read()` repeatedly.
3. Call `yyjson_incr_free()` to free the state.

A new error code `YYJSON_READ_ERROR_MORE` indicates incremental read is incomplete and can be resumed.

Conditional compilation is possible with `-DYYJSON_DISABLE_INCREMENTAL=ON`/`OFF`.

Example code:

```C
const char *dat = ...
size_t len = ...

yyjson_read_flag flg = YYJSON_READ_NOFLAG;
yyjson_incr_state *state = yyjson_incr_new((char *)dat, len, flg, NULL);
yyjson_doc *doc;
yyjson_read_err err;
size_t read_so_far = 0;
do {
    read_so_far += 100000;
    if (read_so_far > len)
        read_so_far = len;
    doc = yyjson_incr_read(state, read_so_far, &err);
    if (err.code != YYJSON_READ_ERROR_MORE)
        break;
} while (read_so_far < len);
yyjson_incr_free(state);

if (doc != NULL) { ... }

yyjson_doc_free(doc);
```

Additional changes:

* Some changes in the position returned for errors in incomplete escape sequences in strings. Some test cases in `test_err_code.c` needed to be adjusted.
* Limit the length of numbers when incremental read is used, to avoid DOS attacks with very long numbers.

Closes #191