### PR TITLE
Add a read option to allow UTF-8 BOM

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -341,6 +341,9 @@ This flag permits invalid characters to appear in the string values, but it stil
 
 ***Warning***: when using this option, be aware that strings within JSON values may contain incorrect encoding, so you need to handle these strings carefully to avoid security risks.
 
+● **YYJSON_READ_ALLOW_BOM**<br/>
+Allow UTF-8 BOM and skip it before parsing if any (non-standard).
+
 
 ---------------
 # Writing JSON

--- a/src/yyjson.h
+++ b/src/yyjson.h
@@ -808,6 +808,9 @@ static const yyjson_read_flag YYJSON_READ_ALLOW_INVALID_UNICODE = 1 << 6;
     The flag will be overridden by `YYJSON_READ_NUMBER_AS_RAW` flag. */
 static const yyjson_read_flag YYJSON_READ_BIGNUM_AS_RAW         = 1 << 7;
 
+/** Allow UTF-8 BOM and skip it before parsing if any (non-standard). */
+static const yyjson_read_flag YYJSON_READ_ALLOW_BOM             = 1 << 8;
+
 
 
 /** Result code for JSON reader. */

--- a/test/test_err_code.c
+++ b/test/test_err_code.c
@@ -731,6 +731,16 @@ static void test_locate_pos(void) {
         yy_assert(yyjson_locate_pos(buf, len, pos, &line, &col, &chr));
         yy_assert(line == 1 && col == pos + 1 && chr == pos);
     }
+    // UTF-8 BOM.
+    buf[0] = 0xEF;
+    buf[1] = 0xBB;
+    buf[2] = 0xBF;
+    for (pos = 0; pos <= len; pos++) {
+        // Don't count BOM as a character.
+        size_t pos_uni = pos < 3 ? 0 : pos - 3;
+        yy_assert(yyjson_locate_pos(buf, len, pos, &line, &col, &chr));
+        yy_assert(line == 1 && col == pos_uni + 1 && chr == pos_uni);
+    }
 }
 
 

--- a/test/test_json_reader.c
+++ b/test/test_json_reader.c
@@ -18,7 +18,8 @@ typedef enum {
     FLAG_INF_NAN    = 1 << 2,
     FLAG_EXTRA      = 1 << 3,
     FLAG_NUM_RAW    = 1 << 4,
-    FLAG_MAX        = 1 << 5,
+    FLAG_BOM        = 1 << 5,
+    FLAG_MAX        = 1 << 6,
 } flag_type;
 
 static void test_read_file(const char *path, flag_type type, expect_type expect) {
@@ -41,6 +42,7 @@ static void test_read_file(const char *path, flag_type type, expect_type expect)
     if (type & FLAG_INF_NAN) flag |= YYJSON_READ_ALLOW_INF_AND_NAN;
     if (type & FLAG_EXTRA) flag |= YYJSON_READ_STOP_WHEN_DONE;
     if (type & FLAG_NUM_RAW) flag |= YYJSON_READ_NUMBER_AS_RAW;
+    if (type & FLAG_BOM) flag |= YYJSON_READ_ALLOW_BOM;
     
     // test read from file
     yyjson_read_err err;
@@ -278,8 +280,13 @@ static void test_json_encoding(void) {
         
         if (strcmp(name, "utf8.json") == 0) {
             test_read_file(path, FLAG_NONE, EXPECT_PASS);
+            test_read_file(path, FLAG_BOM, EXPECT_PASS);
+        } else if (strcmp(name, "utf8bom.json") == 0) {
+            test_read_file(path, FLAG_NONE, EXPECT_FAIL);
+            test_read_file(path, FLAG_BOM, EXPECT_PASS);
         } else {
             test_read_file(path, FLAG_NONE, EXPECT_FAIL);
+            test_read_file(path, FLAG_BOM, EXPECT_FAIL);
         }
     }
     yy_dir_free(names);


### PR DESCRIPTION
simdjson also skips UTF-8 BOM before parsing: https://github.com/simdjson/simdjson/blob/v3.12.3/include/simdjson/generic/ondemand/parser-inl.h#L54