### PR TITLE
Fix CMake deprecation warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Released under the MIT License:
 # https://github.com/ibireme/yyjson/blob/master/LICENSE
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...3.31)
 project(yyjson VERSION 0.10.0 LANGUAGES C)
 set(YYJSON_SOVERSION 0)
 


### PR DESCRIPTION
In CMake 3.27 and above, there will be a compatibility warning for CMake versions below 3.5.
In CMake 4.0, there will be a compatibility warning for versions below 3.10.

![图片](https://github.com/user-attachments/assets/f6ccbabe-ba51-4dc5-a0fb-f77a254935f8)


Therefore, use the `min...max` approach to eliminate these warnings. This way, support for older versions of CMake can still be retained.

References:

- https://github.com/vector-of-bool/cmrc/pull/48
- https://github.com/open-source-parsers/jsoncpp/pull/1499
- https://github.com/zeromq/libzmq/pull/4776