### PR TITLE
CI: Reduce dependencies for FreeBSD

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -365,7 +365,7 @@ jobs:
       with:
         usesh: true
         run: |
-          pkg install -y cmake
+          pkg install -y cmake-core
           mkdir build
           cd build
           cmake .. -DCMAKE_BUILD_TYPE=Release -DYYJSON_BUILD_TESTS=ON


### PR DESCRIPTION
Install the package cmake-core which is cmake "base" instead of cmake which is a meta-port and pulls in a lot more deps.

https://cgit.freebsd.org/ports/tree/devel/cmake/Makefile
https://cgit.freebsd.org/ports/tree/devel/cmake-core/Makefile