### PR TITLE
Add Unicode replacement and surrogate tolerance flags

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -758,12 +758,14 @@ Each JSON Value has a type and subtype, as specified in the table:
 | YYJSON_TYPE_NUM  | YYJSON_SUBTYPE_REAL  | `double` number         |
 | YYJSON_TYPE_STR  |                      | String value            |
 | YYJSON_TYPE_STR  | YYJSON_SUBTYPE_NOESC | String value, no-escape |
+| YYJSON_TYPE_STR  | YYJSON_SUBTYPE_UNIERR | String value, invalid unicode |
 | YYJSON_TYPE_ARR  |                      | Array value             |
 | YYJSON_TYPE_OBJ  |                      | Object value            |
 
 - `YYJSON_TYPE_NONE` means invalid value, it does not appear when the JSON is successfully parsed.
 - `YYJSON_TYPE_RAW` only appears when the corresponding flag `YYJSON_READ_XXX_AS_RAW` is used.
 - `YYJSON_SUBTYPE_NOESC` is used to optimize the writing speed of strings that do not need to be escaped. This subtype is used internally, and the user does not need to handle it.
+- `YYJSON_SUBTYPE_UNIERR` marks strings that contained invalid Unicode during parsing. Such strings may require special handling.
 
 The following functions can be used to determine the type of a JSON value.
 

--- a/src/yyjson.h
+++ b/src/yyjson.h
@@ -760,14 +760,13 @@ static const yyjson_read_flag YYJSON_READ_ALLOW_INF_AND_NAN         = 1 << 4;
     inf/nan literal is also read as raw with `ALLOW_INF_AND_NAN` flag. */
 static const yyjson_read_flag YYJSON_READ_NUMBER_AS_RAW             = 1 << 5;
 
-/** Allow reading invalid unicode when parsing string values (non-standard).
-    Invalid characters will be allowed to appear in the string values, but
-    invalid escape sequences will still be reported as errors.
-    This flag does not affect the performance of correctly encoded strings.
+/** Allow reading raw invalid UTF-8 bytes in strings (non-standard).
+    This flag only affects raw bytes; `\uXXXX` escapes still require valid
+    surrogate pairs unless `YYJSON_READ_ALLOW_INVALID_SURROGATE` is also set.
+    Invalid escape sequences will still be reported as errors.
 
-    @warning Strings in JSON values may contain incorrect encoding when this
-    option is used, you need to handle these strings carefully to avoid security
-    risks. */
+    @warning Strings may contain ill-formed UTF-8 when this option is used,
+    you need to handle these strings carefully to avoid security risks. */
 static const yyjson_read_flag YYJSON_READ_ALLOW_INVALID_UNICODE     = 1 << 6;
 
 /** Read big numbers as raw strings. These big numbers include integers that
@@ -809,6 +808,22 @@ static const yyjson_read_flag YYJSON_READ_ALLOW_SINGLE_QUOTED_STR   = 1 << 12;
     This extends the ECMAScript IdentifierName rule by allowing any
     non-whitespace character with code point above `U+007F`. */
 static const yyjson_read_flag YYJSON_READ_ALLOW_UNQUOTED_KEY        = 1 << 13;
+
+/** Replace invalid unicode code units with replacement character `U+FFFD`
+    when parsing string values (non-standard).
+    This flag implicitly enables `YYJSON_READ_ALLOW_INVALID_UNICODE` and
+    `YYJSON_READ_ALLOW_INVALID_SURROGATE`, so malformed input is tolerated
+    and replaced without needing those flags.
+    Note: when compiled with `YYJSON_DISABLE_UTF8_VALIDATION=ON`, invalid
+    UTF-8 byte sequences are not detected and therefore not replaced. */
+static const yyjson_read_flag YYJSON_READ_REPLACE_INVALID_UNICODE   = 1 << 14;
+
+/** Allow unpaired surrogate code units in `\uXXXX` escapes (non-standard).
+    Raw invalid UTF-8 bytes are unaffected; use
+    `YYJSON_READ_ALLOW_INVALID_UNICODE` for that. When combined with
+    `YYJSON_READ_REPLACE_INVALID_UNICODE`, the surrogates are replaced with
+    `U+FFFD`. */
+static const yyjson_read_flag YYJSON_READ_ALLOW_INVALID_SURROGATE   = 1 << 15;
 
 /** Allow JSON5 format, see: [https://json5.org].
     This flag supports all JSON5 features with some additional extensions:

--- a/test/test_string.c
+++ b/test/test_string.c
@@ -1455,7 +1455,7 @@ static void test_unquoted_key(void) {
 /*----------------------------------------------------------------------------*/
 
 static void test_invalid_unicode_flags(void) {
-#if !YYJSON_DISABLE_READER
+#if !YYJSON_DISABLE_READER && !YYJSON_DISABLE_NON_STANDARD
     /* unpaired surrogate */
     char inv_sur_hi[8 + YYJSON_PADDING_SIZE];
     memcpy(inv_sur_hi, "\"\\uD83D\"", 8);
@@ -1562,7 +1562,7 @@ static void test_invalid_unicode_flags(void) {
     yy_assert(yyjson_get_len(val) == 3);
     yy_assert(yyjson_get_subtype(val) == YYJSON_SUBTYPE_UNIERR);
     yyjson_doc_free(doc);
-#endif
+#endif /* !YYJSON_DISABLE_READER && !YYJSON_DISABLE_NON_STANDARD */
 }
 
 


### PR DESCRIPTION
Add `YYJSON_READ_REPLACE_INVALID_UNICODE` and `YYJSON_READ_ALLOW_INVALID_SURROGATE` flags to enable graceful handling of malformed Unicode in JSON strings.

`YYJSON_READ_REPLACE_INVALID_UNICODE` replaces all invalid Unicode sequences with `U+FFFD` replacement character, ensuring output is always valid UTF-8. Handles invalid \uXXXX escapes, unpaired surrogates, invalid UTF-8 bytes, and control characters.

`YYJSON_READ_ALLOW_INVALID_SURROGATE` permits unpaired surrogate code units in \uXXXX escapes, encoding them as UTF-8.

__Key changes__

- Modified read_uni_esc() to accept flags parameter
- Added replacement logic throughout string parsing paths
- Replacement flag implicitly enables unicode tolerance flags
- Added comprehensive test coverage
- Flags not supported in incremental parsing mode

__why ?__

- This enables robust parsing of real-world JSON with encoding errors while maintaining strict standards compliance by default.
- While we would love to live in strict parsing mode, we have to deal with malformed data, dealing with invalid bytes is times expensive in the caller than handling this directly inside yyjson  