### PR TITLE
Add ReerJSON as a user of yyjson

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ yyjson, feel free to open a PR to add it to this list.
 | [reflect-cpp][] | C++      | C++ library for serialization through automated field name retrieval from structs        |
 | [yyjsonr][]     | R        | R binding for yyjson                                                                     |
 | [Ananda][]      | Swift    | JSON model decoding based on yyjson                                                      |
+| [ReerJSON][]    | Swift    | A faster version of JSONDecoder based on yyjson                                          |
 | [duckdb][]      | C++      | DuckDB is an in-process SQL OLAP Database Management System                              |
 | [fastfetch][]   | C        | A neofetch-like tool for fetching system information and displaying them in a pretty way |
 | [Zrythm][]      | C        | Digital Audio Workstation that uses yyjson to serialize JSON project files               |
@@ -249,6 +250,7 @@ This project is released under the MIT license.
 [reflect-cpp]: https://github.com/getml/reflect-cpp
 [yyjsonr]: https://github.com/coolbutuseless/yyjsonr
 [Ananda]: https://github.com/nixzhu/Ananda
+[ReerJSON]: https://github.com/reers/ReerJSON
 [duckdb]: https://github.com/duckdb/duckdb
 [fastfetch]: https://github.com/fastfetch-cli/fastfetch
 [Zrythm]: https://github.com/zrythm/zrythm


### PR DESCRIPTION
Hi, I have created a Swift JSONDecoder based on yyjson, compared with Apple's implementation, ReerJSON fully implements all APIs, and thanks to the powerful yyjson, ReerJSON has higher performance.
Thanks for all your great work! 