### PR TITLE
Add optional compile-time depth limit for reader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ option(YYJSON_DISABLE_FAST_FP_CONV "Disable custom floating-point number convers
 option(YYJSON_DISABLE_NON_STANDARD "Disable non-standard JSON support" OFF)
 option(YYJSON_DISABLE_UTF8_VALIDATION "Disable UTF-8 validation" OFF)
 option(YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS "Disable unaligned memory access explicit" OFF)
+option(YYJSON_READER_DEPTH_LIMIT "Set a depth limit for reading nested objects/arrays, 0 for unlimited" 0)
 
 if(YYJSON_DISABLE_READER)
     add_definitions(-DYYJSON_DISABLE_READER)
@@ -69,7 +70,9 @@ endif()
 if(YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS)
     add_definitions(-DYYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS)
 endif()
-
+if(YYJSON_READER_DEPTH_LIMIT GREATER 0)
+    add_definitions(-DYYJSON_READER_DEPTH_LIMIT=${YYJSON_READER_DEPTH_LIMIT})
+endif()
 
 
 # ------------------------------------------------------------------------------
@@ -527,6 +530,13 @@ if(YYJSON_BUILD_MISC)
     add_executable(make_tables "misc/make_tables.c")
     if(XCODE)
         set_default_xcode_property(make_tables)
+    endif()
+
+    # depth-limit experiment; only does anything if YYJSON_READER_DEPTH_LIMIT is set
+    add_executable(experiment_depth_limit "misc/experiment_depth_limit.c")
+    target_link_libraries(experiment_depth_limit PRIVATE yyjson)
+    if(XCODE)
+        set_default_xcode_property(experiment_depth_limit)
     endif()
 endif()
 

--- a/misc/experiment_depth_limit.c
+++ b/misc/experiment_depth_limit.c
@@ -1,0 +1,65 @@
+#include "yyjson.h"
+
+#if YYJSON_READER_DEPTH_LIMIT
+static void make_nested_json_arrays(char *json, int depth)
+{
+    char *jsonp = json;
+    for (int i = 0; i < depth; i++) {
+        *jsonp++ = '[';
+    }
+    *jsonp++ = '8';
+    for (int i = 0; i < depth; i++) {
+        *jsonp++ = ']';
+    }
+    *jsonp = 0;
+}
+static void make_nested_json_objects(char *json, int depth)
+{
+    char *jsonp = json;
+    for (int i = 0; i < depth; i++) {
+        *jsonp++ = '{';
+        *jsonp++ = '"';
+        *jsonp++ = 'a' + i % 26;
+        *jsonp++ = '"';
+        *jsonp++ = ':';
+    }
+    *jsonp++ = '8';
+    for (int i = 0; i < depth; i++) {
+        *jsonp++ = '}';
+    }
+    *jsonp = 0;
+}
+
+static int check_parse(char *json)
+{
+    yyjson_read_err err;
+    yyjson_doc *doc;
+    yyjson_val *val;
+    printf("Parsing: %s, depth limit = %d\n", json, YYJSON_READER_DEPTH_LIMIT);
+    doc = yyjson_read_opts(json, strlen(json), 0, NULL, &err);
+    yyjson_doc_free(doc);
+    printf("=> Error code: %d\n", err.code);
+    if (err.code != YYJSON_READ_ERROR_DEPTH)
+    {
+        printf("Expected depth error, but didn't get one!");
+        return 1;
+    }
+    return 0;
+}
+
+int main()
+{
+    char json[512];
+    make_nested_json_arrays(json, YYJSON_READER_DEPTH_LIMIT + 1);
+    check_parse(json);
+    make_nested_json_objects(json, YYJSON_READER_DEPTH_LIMIT + 1);
+    check_parse(json);
+    return 0;
+}
+#else
+int main()
+{
+    printf("Library not compiled with depth limit support.\n");
+    return 0;
+}
+#endif

--- a/src/yyjson.h
+++ b/src/yyjson.h
@@ -142,6 +142,9 @@
 #ifndef YYJSON_HAS_STDBOOL_H
 #endif
 
+/* Define to an integer to set a depth limit for containers (arrays, objects). */
+#ifndef YYJSON_READER_DEPTH_LIMIT
+#endif
 
 
 /*==============================================================================
@@ -874,6 +877,9 @@ static const yyjson_read_code YYJSON_READ_ERROR_FILE_READ               = 13;
 
 /** Incomplete input during incremental parsing; parsing state is preserved. */
 static const yyjson_read_code YYJSON_READ_ERROR_MORE                    = 14;
+
+/** Read depth limit exceeded. */
+static const yyjson_read_code YYJSON_READ_ERROR_DEPTH                   = 15;
 
 /** Error information for JSON reader. */
 typedef struct yyjson_read_err {


### PR DESCRIPTION
Idea [based on the patch in orjson](https://github.com/ijl/orjson/blob/master/include/yyjson-recursion-limit.patch).

When no limit is compiled in, there is no performance impact.

I didn't add a test case (seemed pretty hairy to do so while keeping the rest of the tests intact, but let me know if there's a neat way to do that), but there's an "experiment" file you can run:

Use e.g.

```
cmake -B cmake-build-limit . -D YYJSON_BUILD_MISC=true -D YYJSON_BUILD_TESTS=false -D YYJSON_READER_DEPTH_LIMIT=50
cmake --build cmake-build-limit
./cmake-build-limit/experiment_depth_limit
```

to see this in action:

```
Parsing: [[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[8]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]], depth limit = 50
=> Error code: 15
Parsing: {"a":{"b":{"c":{"d":{"e":{"f":{"g":{"h":{"i":{"j":{"k":{"l":{"m":{"n":{"o":{"p":{"q":{"r":{"s":{"t":{"u":{"v":{"w":{"x":{"y":{"z":{"a":{"b":{"c":{"d":{"e":{"f":{"g":{"h":{"i":{"j":{"k":{"l":{"m":{"n":{"o":{"p":{"q":{"r":{"s":{"t":{"u":{"v":{"w":{"x":{"y":8}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}, depth limit = 50
=> Error code: 15
```