### PR TITLE
 Add “serin” - a multi-format (YAML, JSON, TOON) C++/Python serialization library using yyjson

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,21 +213,22 @@ A non-exhaustive list of projects that expose yyjson to other languages or
 use yyjson internally for a major feature. If you have a project that uses
 yyjson, feel free to open a PR to add it to this list.
 
-| Project         | Language | Description                                                                              |
-|-----------------|----------|------------------------------------------------------------------------------------------|
-| [py_yyjson][]   | Python   | Python bindings for yyjson                                                               |
-| [orjson][]      | Python   | JSON library for Python with an optional yyjson backend                                  |
-| [cpp-yyjson][]  | C++      | C++ JSON library with a yyjson backend                                                   |
-| [reflect-cpp][] | C++      | C++ library for serialization through automated field name retrieval from structs        |
-| [yyjsonr][]     | R        | R binding for yyjson                                                                     |
-| [Ananda][]      | Swift    | JSON model decoding based on yyjson                                                      |
-| [ReerJSON][]    | Swift    | A faster version of JSONDecoder based on yyjson                                          |
-| [duckdb][]      | C++      | DuckDB is an in-process SQL OLAP Database Management System                              |
-| [fastfetch][]   | C        | A neofetch-like tool for fetching system information and displaying them in a pretty way |
-| [Zrythm][]      | C        | Digital Audio Workstation that uses yyjson to serialize JSON project files               |
-| [bemorehuman][] | C        | Recommendation engine with a focus on uniqueness of the person receiving the rec         |
-| [mruby-yyjson][]| mruby    | Efficient JSON parsing and serialization library for mruby using yyjson                  |
-| [YYJSON.jl][]   | Julia    | Julia bindings for yyjson                                                                |
+| Project         | Language     | Description                                                                                          |
+|-----------------|--------------|------------------------------------------------------------------------------------------------------|
+| [py_yyjson][]   | Python       | Python bindings for yyjson                                                                           |
+| [orjson][]      | Python       | JSON library for Python with an optional yyjson backend                                              |
+| [serin][]       | C++ / Python | a C++ and Python serialization library supporting TOON, JSON, and YAML with cross-format conversion. |
+| [cpp-yyjson][]  | C++          | C++ JSON library with a yyjson backend                                                               |
+| [reflect-cpp][] | C++          | C++ library for serialization through automated field name retrieval from structs                    |
+| [yyjsonr][]     | R            | R binding for yyjson                                                                                 |
+| [Ananda][]      | Swift        | JSON model decoding based on yyjson                                                                  |
+| [ReerJSON][]    | Swift        | A faster version of JSONDecoder based on yyjson                                                      |
+| [duckdb][]      | C++          | DuckDB is an in-process SQL OLAP Database Management System                                          |
+| [fastfetch][]   | C            | A neofetch-like tool for fetching system information and displaying them in a pretty way             |
+| [Zrythm][]      | C            | Digital Audio Workstation that uses yyjson to serialize JSON project files                           |
+| [bemorehuman][] | C            | Recommendation engine with a focus on uniqueness of the person receiving the rec                     |
+| [mruby-yyjson][]| mruby        | Efficient JSON parsing and serialization library for mruby using yyjson                              |
+| [YYJSON.jl][]   | Julia        | Julia bindings for yyjson                                                                            |
 
 # TODO for v1.0
 * [x] Add documentation page.
@@ -246,6 +247,7 @@ This project is released under the MIT license.
 
 [py_yyjson]: https://github.com/tktech/py_yyjson
 [orjson]: https://github.com/ijl/orjson
+[serin]: https://github.com/mohammadraziei/serin
 [cpp-yyjson]: https://github.com/yosh-matsuda/cpp-yyjson
 [reflect-cpp]: https://github.com/getml/reflect-cpp
 [yyjsonr]: https://github.com/coolbutuseless/yyjsonr


### PR DESCRIPTION
Hi 👋

As discussed in [issue #238](https://github.com/ibireme/yyjson/issues/238),
I’ve developed a **serializer/deserializer library** that supports multiple data formats — **YAML**, **JSON**, and **TOON** — and I’m proud to share that it uses **yyjson** as the backend for its JSON handling.

The project is called **[serin](https://github.com/mohammadraziei/serin)** and is a C++ library (with planned Python bindings) designed to provide a unified and lightweight serialization API.

I’d be truly grateful if you could **merge this PR** to include it in the list of projects using yyjson.

Thank you very much for your amazing work on yyjson — it made this possible 🙏

Best regards,
**Mohammad Raziei**

