### PR TITLE
Add swift-yyjson project to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,23 +213,24 @@ A non-exhaustive list of projects that expose yyjson to other languages or
 use yyjson internally for a major feature. If you have a project that uses
 yyjson, feel free to open a PR to add it to this list.
 
-| Project         | Language     | Description                                                                                          |
-|-----------------|--------------|------------------------------------------------------------------------------------------------------|
-| [py_yyjson][]   | Python       | Python bindings for yyjson                                                                           |
-| [orjson][]      | Python       | JSON library for Python with an optional yyjson backend                                              |
-| [serin][]       | C++ / Python | a C++ and Python serialization library supporting TOON, JSON, and YAML with cross-format conversion. |
-| [cpp-yyjson][]  | C++          | C++ JSON library with a yyjson backend                                                               |
-| [reflect-cpp][] | C++          | C++ library for serialization through automated field name retrieval from structs                    |
-| [xyjson][]      | C++          | C++ proxy and wrapper for yyjson with convenient operator overloading                                |
-| [yyjsonr][]     | R            | R binding for yyjson                                                                                 |
-| [Ananda][]      | Swift        | JSON model decoding based on yyjson                                                                  |
-| [ReerJSON][]    | Swift        | A faster version of JSONDecoder based on yyjson                                                      |
-| [duckdb][]      | C++          | DuckDB is an in-process SQL OLAP Database Management System                                          |
-| [fastfetch][]   | C            | A neofetch-like tool for fetching system information and displaying them in a pretty way             |
-| [Zrythm][]      | C            | Digital Audio Workstation that uses yyjson to serialize JSON project files                           |
-| [bemorehuman][] | C            | Recommendation engine with a focus on uniqueness of the person receiving the rec                     |
-| [mruby-yyjson][]| mruby        | Efficient JSON parsing and serialization library for mruby using yyjson                              |
-| [YYJSON.jl][]   | Julia        | Julia bindings for yyjson                                                                            |
+| Project          | Language     | Description                                                                                          |
+|------------------|--------------|------------------------------------------------------------------------------------------------------|
+| [py_yyjson][]    | Python       | Python bindings for yyjson                                                                           |
+| [orjson][]       | Python       | JSON library for Python with an optional yyjson backend                                              |
+| [serin][]        | C++ / Python | a C++ and Python serialization library supporting TOON, JSON, and YAML with cross-format conversion. |
+| [cpp-yyjson][]   | C++          | C++ JSON library with a yyjson backend                                                               |
+| [reflect-cpp][]  | C++          | C++ library for serialization through automated field name retrieval from structs                    |
+| [xyjson][]       | C++          | C++ proxy and wrapper for yyjson with convenient operator overloading                                |
+| [yyjsonr][]      | R            | R binding for yyjson                                                                                 |
+| [Ananda][]       | Swift        | JSON model decoding based on yyjson                                                                  |
+| [ReerJSON][]     | Swift        | A faster version of JSONDecoder based on yyjson                                                      |
+| [swift-yyjson][] | Swift        | A fast JSON library for Swift, powered by yyjson                                                     |
+| [duckdb][]       | C++          | DuckDB is an in-process SQL OLAP Database Management System                                          |
+| [fastfetch][]    | C            | A neofetch-like tool for fetching system information and displaying them in a pretty way             |
+| [Zrythm][]       | C            | Digital Audio Workstation that uses yyjson to serialize JSON project files                           |
+| [bemorehuman][]  | C            | Recommendation engine with a focus on uniqueness of the person receiving the rec                     |
+| [mruby-yyjson][] | mruby        | Efficient JSON parsing and serialization library for mruby using yyjson                              |
+| [YYJSON.jl][]    | Julia        | Julia bindings for yyjson                                                                            |
 
 # TODO for v1.0
 * [x] Add documentation page.
@@ -255,6 +256,7 @@ This project is released under the MIT license.
 [yyjsonr]: https://github.com/coolbutuseless/yyjsonr
 [Ananda]: https://github.com/nixzhu/Ananda
 [ReerJSON]: https://github.com/reers/ReerJSON
+[swift-yyjson]: https://github.com/mattt/swift-yyjson
 [duckdb]: https://github.com/duckdb/duckdb
 [fastfetch]: https://github.com/fastfetch-cli/fastfetch
 [Zrythm]: https://github.com/zrythm/zrythm


### PR DESCRIPTION
Hello, @ibireme. Thank you for your work on yyjson!

I recently learned about your project from a PR by @DePasqualeOrg to swift-transformers (https://github.com/huggingface/swift-transformers/pull/304). That led me to creating a Swift package to wrapping it here: https://github.com/mattt/swift-yyjson

In contrast to the other Swift projects already mentioned in the README, this package provides API-compatible replacements for standard Swift APIs, and uses package trait equivalents for compile-time optimizations. [^1]

Hoping to add benchmarks and more comprehensive testing soon. But wanted to share this with you to get your thoughts and give it more visibility to anyone else who's using yyjson in their apps.

[^1]: Currently, `swift-yyjson` vendors C code instead of declaring yyjson as a dependency. While that is possible because yyjson contains a root-level `Package.swift` file (#11), that package manifest file doesn't include traits that allow for compile-time options. Let me know if you'd be interested in a PR implementing that! (It should be possible without impacting existing compatibility)