### PR TITLE
Add package traits for compile-time configuration

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version: 6.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,19 +6,44 @@ import PackageDescription
 let package = Package(
     name: "yyjson",
     products: [
-        // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "yyjson",
-            targets: ["yyjson"]),
+            targets: ["yyjson"]
+        )
+    ],
+    traits: [
+        .trait(name: "noReader", description: "Omit JSON reader"),
+        .trait(name: "noWriter", description: "Omit JSON writer"),
+        .trait(name: "noIncrementalReader", description: "Omit incremental reader"),
+        .trait(name: "noUtilities", description: "Omit JSON Pointer, Patch, Merge Patch"),
+        .trait(
+            name: "noFastFloatingPoint",
+            description: "Use libc strtod/snprintf"
+        ),
+        .trait(
+            name: "strictStandardJSON",
+            description: "Disable non-standard JSON features"
+        ),
+        .trait(
+            name: "noUTF8Validation",
+            description: "Skip UTF-8 validation"
+        ),
     ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "yyjson",
             path: ".",
             sources: ["src"],
-            publicHeadersPath: "src"
+            publicHeadersPath: "src",
+            cSettings: [
+                .define("YYJSON_DISABLE_READER", to: "1", .when(traits: ["noReader"])),
+                .define("YYJSON_DISABLE_WRITER", to: "1", .when(traits: ["noWriter"])),
+                .define("YYJSON_DISABLE_INCR_READER", to: "1", .when(traits: ["noIncrementalReader"])),
+                .define("YYJSON_DISABLE_UTILS", to: "1", .when(traits: ["noUtilities"])),
+                .define("YYJSON_DISABLE_FAST_FP_CONV", to: "1", .when(traits: ["noFastFloatingPoint"])),
+                .define("YYJSON_DISABLE_NON_STANDARD", to: "1", .when(traits: ["strictStandardJSON"])),
+                .define("YYJSON_DISABLE_UTF8_VALIDATION", to: "1", .when(traits: ["noUTF8Validation"])),
+            ]
         )
     ]
 )

--- a/Package@swift-5.swift
+++ b/Package@swift-5.swift
@@ -1,0 +1,24 @@
+// swift-tools-version:5.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "yyjson",
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "yyjson",
+            targets: ["yyjson"]),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "yyjson",
+            path: ".",
+            sources: ["src"],
+            publicHeadersPath: "src"
+        )
+    ]
+)


### PR DESCRIPTION
Follow-up to https://github.com/ibireme/yyjson/pull/244

yyjson provides several compile-time options via C preprocessor macros that allow developers to disable unused features and reduce binary size. With [Swift 6.1's package traits](https://docs.swift.org/swiftpm/documentation/packagedescription/trait), these options are now configurable directly from Swift Package Manager, making it easy for Swift projects to customize their yyjson builds without modifying source files or managing custom build settings.

This PR adds a Swift 6.1 package manifest with traits for optional features: `noReader`, `noWriter`, `noIncrementalReader`, `noUtilities`, `noFastFloatingPoint`, `strictStandardJSON`, `noUTF8Validation`.

To maintain backwards compatibility, we take advantage of [version-specific manifests](https://docs.swift.org/swiftpm/documentation/packagemanagerdocs/swiftversionspecificpackaging/). This PR renames the original manifest to `Package@swift-5.swift`, which Swift versions before 6.1 will fall back to.

We use this approach currently in [mattt/swift-yyjson](https://github.com/mattt/swift-yyjson) to allow package consumers to tailor their installation according to their particular needs. If this PR is merged and a new minor release is cut, we'll be able to depend directly on this repo as a package dependency, rather than vendoring it as we currently do.