### PR TITLE
Update CI workflow to test Swift Package Manager

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -360,6 +360,27 @@ jobs:
       - name: Build
         run: swift build -c release
 
+  # Check Swift Package Manager with traits (Swift 6.1+)
+  macos_swift_traits:
+    runs-on: macos-15
+    env:
+      DEVELOPER_DIR: "/Applications/Xcode_16.3.app/Contents/Developer"
+    strategy:
+      fail-fast: false
+      matrix:
+        trait:
+          - noReader
+          - noWriter
+          - noIncrementalReader
+          - noUtilities
+          - noFastFloatingPoint
+          - strictStandardJSON
+          - noUTF8Validation
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: swift build -c release --traits ${{ matrix.trait }}
+
   # Check Windows MSVC
   windows_msvc:
     runs-on: windows-latest


### PR DESCRIPTION
Related to #245

This PR updates the CI workflow (`cmake.yml`) to add jobs for building yyjson with Swift Package Manager. This ensures that everything works as expected for developers consuming yyjson as a Swift package dependency.