### PR TITLE
Fix trailing-comma error position for nested containers

### DIFF
--- a/src/yyjson.c
+++ b/src/yyjson.c
@@ -5468,7 +5468,7 @@ arr_val_begin:
         cur++;
         if (likely(ctn_len == 0)) goto arr_end;
         if (has_allow(TRAILING_COMMAS)) goto arr_end;
-        while (*cur != ',') cur--;
+        do { cur--; } while (*cur != ',');
         goto fail_trailing_comma;
     }
     if (char_is_space(*cur)) {
@@ -5562,7 +5562,7 @@ obj_key_begin:
         cur++;
         if (likely(ctn_len == 0)) goto obj_end;
         if (has_allow(TRAILING_COMMAS)) goto obj_end;
-        while (*cur != ',') cur--;
+        do { cur--; } while (*cur != ',');
         goto fail_trailing_comma;
     }
     if (char_is_space(*cur)) {
@@ -5910,7 +5910,7 @@ arr_val_begin:
         cur++;
         if (likely(ctn_len == 0)) goto arr_end;
         if (has_allow(TRAILING_COMMAS)) goto arr_end;
-        while (*cur != ',') cur--;
+        do { cur--; } while (*cur != ',');
         goto fail_trailing_comma;
     }
     if (char_is_space(*cur)) {
@@ -6022,7 +6022,7 @@ obj_key_begin:
         cur++;
         if (likely(ctn_len == 0)) goto obj_end;
         if (has_allow(TRAILING_COMMAS)) goto obj_end;
-        while (*cur != ',') cur--;
+        do { cur--; } while (*cur != ',');
         goto fail_trailing_comma;
     }
     if (char_is_space(*cur)) {
@@ -6858,7 +6858,7 @@ arr_val_continue:
     if (*cur == ']') {
         cur++;
         if (likely(ctn_len == 0)) goto arr_end;
-        while (*cur != ',') cur--;
+        do { cur--; } while (*cur != ',');
         goto fail_trailing_comma;
     }
     if (char_is_space(*cur)) {
@@ -6940,7 +6940,7 @@ obj_key_continue:
     if (likely(*cur == '}')) {
         cur++;
         if (likely(ctn_len == 0)) goto obj_end;
-        while (*cur != ',') cur--;
+        do { cur--; } while (*cur != ',');
         goto fail_trailing_comma;
     }
     if (char_is_space(*cur)) {

--- a/test/test_err_code.c
+++ b/test/test_err_code.c
@@ -308,6 +308,17 @@ static void test_read_err_code(void) {
     
     
     // -------------------------------------------------------------------------
+    // Special case: object member is an array with a trailing comma
+    str = "{\"array\":[1,],\"integer\":35}";
+    //                  ^ trailing comma is not allowed
+    memset(&err, -1, sizeof(err));
+    yyjson_doc_free(yyjson_read_opts((char *)str, strlen(str), 0, NULL, &err));
+    yy_assert(err.code == YYJSON_READ_ERROR_JSON_STRUCTURE);
+    yy_assert(err.pos == strlen(str) - 16);
+    
+    
+    
+    // -------------------------------------------------------------------------
     // Invalid comment, such as unclosed multi-line comment.
 #if !YYJSON_DISABLE_NON_STANDARD
     str = "[123]/*";


### PR DESCRIPTION
The `while`-loop used to back-track to the trailing comma for containers assumes that the cursor is *not* pointing to a comma; this is (often) not necessarily true for container-values that are nested inside another container.