### PR TITLE
fix: undefined behaviour in allocator

### DIFF
--- a/src/yyjson.c
+++ b/src/yyjson.c
@@ -2499,9 +2499,11 @@ static void dyn_free(void *ctx_ptr, void *ptr) {
 yyjson_alc *yyjson_alc_dyn_new(void) {
     const yyjson_alc def = YYJSON_DEFAULT_ALC;
     usize hdr_len = sizeof(yyjson_alc) + sizeof(dyn_ctx);
-    yyjson_alc *alc = (yyjson_alc *)def.malloc(def.ctx, hdr_len);
-    dyn_ctx *ctx = (dyn_ctx *)(void *)(alc + 1);
+    yyjson_alc *alc;
+    dyn_ctx *ctx;
+    alc = (yyjson_alc *)def.malloc(def.ctx, hdr_len);
     if (unlikely(!alc)) return NULL;
+    ctx = (dyn_ctx *)(void *)(alc + 1);
     alc->malloc = dyn_malloc;
     alc->realloc = dyn_realloc;
     alc->free = dyn_free;
@@ -2512,9 +2514,10 @@ yyjson_alc *yyjson_alc_dyn_new(void) {
 
 void yyjson_alc_dyn_free(yyjson_alc *alc) {
     const yyjson_alc def = YYJSON_DEFAULT_ALC;
-    dyn_ctx *ctx = (dyn_ctx *)(void *)(alc + 1);
+    dyn_ctx *ctx;
     dyn_chunk *chunk, *next;
     if (unlikely(!alc)) return;
+    ctx = (dyn_ctx *)(void *)(alc + 1);
     for (chunk = ctx->free_list.next; chunk; chunk = next) {
         next = chunk->next;
         def.free(def.ctx, chunk);


### PR DESCRIPTION
I would like to preface this by saying I have limited experience with high-performance C, so there is a possibility this is intended UB. 

I was working on porting yyjson to the Zig build system when I ran into the following error by ubsan when running the test cases:
```
panic: applying non-zero offset 32 to null pointer
dyn_ctx *ctx = (dyn_ctx *)(void *)(alc + 1);
```

I have remedied the issue by moving the `if(unlikely(!alc))` check before the pointer arithmetic. 

Tested on the [test suite](https://ibireme.github.io/yyjson/doc/doxygen/html/building-and-testing.html#:~:text=tests%3A-,cmake,failure) from the docs, respecting `-Wdeclaration-after-statement`.