### PR TITLE
Add yyjson_write_string_to_buf public API

### DIFF
--- a/src/yyjson.c
+++ b/src/yyjson.c
@@ -10392,6 +10392,22 @@ size_t yyjson_mut_write_buf(char *buf, size_t buf_len,
     return yyjson_mut_val_write_buf(buf, buf_len, root, flg, err);
 }
 
+/*==============================================================================
+ * MARK: - Public single-string writer
+ *============================================================================*/
+/* Thin wrapper exposing the internal write_str() to callers building
+ * JSON one-stage from their own value tree. See header docstring. */
+char *yyjson_write_string_to_buf(char *cur, const char *str, size_t str_len,
+                                 yyjson_write_flag flg) {
+    bool esc = has_flg(ESCAPE_UNICODE) != 0;
+    bool inv = has_flg(ALLOW_INVALID_UNICODE) != 0;
+    const char_enc_type *enc_table = get_enc_table_with_flag(flg);
+    const u8 *hex_table = get_hex_table_with_flag(flg);
+    return (char *)write_str((u8 *)cur, esc, inv,
+                             (const u8 *)str, (usize)str_len,
+                             enc_table, hex_table);
+}
+
 #undef has_flg
 #undef has_allow
 #endif /* YYJSON_DISABLE_WRITER */

--- a/src/yyjson.h
+++ b/src/yyjson.h
@@ -1823,6 +1823,34 @@ yyjson_api_inline char *yyjson_mut_write_number(const yyjson_mut_val *val,
     return yyjson_write_number((const yyjson_val *)val, buf);
 }
 
+/**
+ Write a JSON-quoted, escaped string into a caller-provided buffer.
+
+ Companion to `yyjson_write_number()`. Useful for callers that
+ maintain their own value tree (e.g. a language binding's native
+ type) and want to emit JSON one-stage into their own buffer without
+ going through the `yyjson_mut_doc` construction overhead.
+
+ @param cur The buffer cursor; output is written starting here.
+        The buffer MUST have at least `str_len * 6 + 2` bytes
+        of capacity to fit the worst-case `\uXXXX` expansion
+        plus the surrounding double quotes.
+ @param str The UTF-8 source string. Null-terminator not required.
+ @param str_len Length of `str` in bytes.
+ @param flg Write flags. Honors:
+        - `YYJSON_WRITE_ESCAPE_UNICODE`
+        - `YYJSON_WRITE_ESCAPE_SLASHES`
+        - `YYJSON_WRITE_ALLOW_INVALID_UNICODE`
+        - `YYJSON_WRITE_LOWERCASE_HEX`
+        Other flags are ignored.
+ @return The buffer cursor advanced past the closing quote, or NULL
+         on invalid UTF-8 when `ALLOW_INVALID_UNICODE` is unset.
+ */
+yyjson_api char *yyjson_write_string_to_buf(char *cur,
+                                            const char *str,
+                                            size_t str_len,
+                                            yyjson_write_flag flg);
+
 #endif /* YYJSON_DISABLE_WRITER */
 
 

--- a/test/test_string_writer.c
+++ b/test/test_string_writer.c
@@ -1,0 +1,99 @@
+// This file is used to test yyjson_write_string_to_buf.
+
+#include "yyjson.h"
+#include "yy_test_utils.h"
+
+#if !YYJSON_DISABLE_WRITER
+
+static void check_ok(const char *label, const char *src, size_t src_len,
+                     yyjson_write_flag flg, const char *want) {
+    char buf[256];
+    char *end = yyjson_write_string_to_buf(buf, src, src_len, flg);
+    yy_assertf(end != NULL, "%s: returned NULL", label);
+    *end = '\0';
+    yy_assertf(strcmp(buf, want) == 0,
+               "%s: got=%s want=%s", label, buf, want);
+}
+
+static void check_fail(const char *label, const char *src, size_t src_len,
+                       yyjson_write_flag flg) {
+    char buf[256];
+    char *end = yyjson_write_string_to_buf(buf, src, src_len, flg);
+    yy_assertf(end == NULL, "%s: expected NULL, got non-NULL", label);
+}
+
+yy_test_case(test_string_writer) {
+    // Plain ASCII with embedded quote: gets surrounded by quotes,
+    // inner quote escaped.
+    check_ok("ascii embedded quote",
+             "hello \"world\"", 13, 0,
+             "\"hello \\\"world\\\"\"");
+
+    // Slash is not escaped by default.
+    check_ok("slash default", "a/b", 3, 0, "\"a/b\"");
+
+    // Slash escaped under YYJSON_WRITE_ESCAPE_SLASHES.
+    check_ok("slash escaped", "a/b", 3,
+             YYJSON_WRITE_ESCAPE_SLASHES, "\"a\\/b\"");
+
+    // Multibyte UTF-8 passes through verbatim by default.
+    check_ok("utf8 raw", "\xE2\x98\x83", 3, 0, "\"\xE2\x98\x83\"");
+
+    // Same character emitted as \uXXXX with ESCAPE_UNICODE (uppercase hex).
+    check_ok("utf8 escape unicode upper",
+             "\xE2\x98\x83", 3, YYJSON_WRITE_ESCAPE_UNICODE,
+             "\"\\u2603\"");
+
+    // LOWERCASE_HEX changes the hex case in \uXXXX escapes.
+    check_ok("u00FF upper hex",
+             "\xC3\xBF", 2, YYJSON_WRITE_ESCAPE_UNICODE,
+             "\"\\u00FF\"");
+    check_ok("u00FF lower hex",
+             "\xC3\xBF", 2,
+             YYJSON_WRITE_ESCAPE_UNICODE | YYJSON_WRITE_LOWERCASE_HEX,
+             "\"\\u00ff\"");
+
+    // Control characters get short-form escapes.
+    check_ok("control newline",
+             "line\nbreak", 10, 0, "\"line\\nbreak\"");
+
+    // Invalid UTF-8 with ALLOW_INVALID_UNICODE -> replacement character.
+    check_ok("invalid utf8 allowed",
+             "\xFF", 1,
+             YYJSON_WRITE_ALLOW_INVALID_UNICODE |
+             YYJSON_WRITE_ESCAPE_UNICODE,
+             "\"\\uFFFD\"");
+
+    // Invalid UTF-8 without ALLOW_INVALID_UNICODE -> NULL.
+    check_fail("invalid utf8 rejected", "\xFF", 1, 0);
+
+    // Empty string -> "".
+    check_ok("empty", "", 0, 0, "\"\"");
+
+    // Round-trip: write_string_to_buf output equals the string part
+    // of yyjson_mut_write for the same input.
+    {
+        const char *src = "round/trip \"check\"\n";
+        size_t src_len = strlen(src);
+        char direct[128];
+        char *end = yyjson_write_string_to_buf(direct, src, src_len, 0);
+        yy_assert(end != NULL);
+        *end = '\0';
+
+        yyjson_mut_doc *doc = yyjson_mut_doc_new(NULL);
+        yyjson_mut_val *v = yyjson_mut_strn(doc, src, src_len);
+        yyjson_mut_doc_set_root(doc, v);
+        size_t two_stage_len = 0;
+        char *two_stage = yyjson_mut_write(doc, 0, &two_stage_len);
+        yy_assert(two_stage != NULL);
+        yy_assertf(strcmp(direct, two_stage) == 0,
+                   "round-trip mismatch: direct=%s two_stage=%s",
+                   direct, two_stage);
+        free(two_stage);
+        yyjson_mut_doc_free(doc);
+    }
+}
+
+#else
+yy_test_case(test_string_writer) {}
+#endif


### PR DESCRIPTION
Resolves #265.

Companion to `yyjson_write_number()`. Exposes the existing internal `write_str()` so callers building JSON one-stage from their own value tree can reuse yyjson's escape-table writer without going through `yyjson_mut_doc` construction.

## Use case

PHP extensions that wrap yyjson currently choose between:

1. **Two-stage**: walk native values into a `yyjson_mut_doc`, then `yyjson_mut_write_opts`. Per-value `mut_val` allocation hurts on workloads with many small JSON values.
2. **One-stage**: walk values straight into a buffer, emit tokens inline. `yyjson_write_number()` is already public for int/double via stack-allocated `yyjson_val`, but no equivalent for strings forces wrappers to either lift the escape writer or stay on two-stage.

This patch is the missing piece.

## Verified

Functional test on the patched build (input `hello "world"`, default flags):

    Output: "hello \"world\"" matches yyjson_mut_write expectation

Builds clean (CMake Release, gcc 14, no new warnings).
