### PR TITLE
Reject len == SIZE_MAX in unsafe_yyjson_mut_str_alc

### DIFF
--- a/src/yyjson.h
+++ b/src/yyjson.h
@@ -5790,6 +5790,10 @@ yyjson_api_inline char *unsafe_yyjson_mut_str_alc(yyjson_mut_doc *doc,
     char *mem;
     const yyjson_alc *alc = &doc->alc;
     yyjson_str_pool *pool = &doc->str_pool;
+    /* `len + 1` is used below to reserve space for a null terminator;
+       reject the value that would wrap it to 0 and produce an under-sized
+       allocation with an out-of-bounds memcpy at the call sites. */
+    if (yyjson_unlikely(len == (size_t)-1)) return NULL;
     if (yyjson_unlikely((size_t)(pool->end - pool->cur) <= len)) {
         if (yyjson_unlikely(!unsafe_yyjson_str_pool_grow(pool, alc, len + 1))) {
             return NULL;


### PR DESCRIPTION
## Bug

`unsafe_yyjson_mut_str_alc()` in `src/yyjson.h` computes `len + 1` (to reserve a
null terminator) without first checking whether the caller-supplied `len` is
`(size_t)-1`. When that happens:

* `len + 1` wraps to `0`.
* The grow path passes `0` to `unsafe_yyjson_str_pool_grow()`, which checks
  `len > USIZE_MAX - sizeof(yyjson_str_chunk)` -- `0 > max_len` is false, so the
  grow proceeds and allocates a tiny chunk.
* The non-grow path is also bypassed: `(pool->end - pool->cur) <= len` is true
  for the wrapped SIZE_MAX value.
* `pool->cur = mem + len + 1` wraps back to `mem`.
* `unsafe_yyjson_mut_strncpy()` (and every caller listed below) then runs
  `memcpy(mem, str, (size_t)-1)`, which reads SIZE_MAX bytes from the caller's
  buffer into a chunk that does not have anywhere close to that much space.

The vulnerable helper sits behind every public mutable-string API that forwards
an untrusted length unchanged, including `yyjson_mut_strncpy()`,
`yyjson_mut_rawncpy()`, `yyjson_mut_obj_add_strncpy()`,
`yyjson_mut_arr_with_strncpy()`, and `yyjson_mut_arr_with_strn()` (the last via
`unsafe_yyjson_set_strn` after copy). Any service that derives the length from
attacker-controlled data and passes it straight in is exposed.

## Reproducer

Compiled against the current tree with AddressSanitizer:

```c
yyjson_mut_doc *doc = yyjson_mut_doc_new(NULL);
const char src[8] = "abcdefg";
yyjson_mut_strncpy(doc, src, (size_t)-1);
```

```
==ERROR: AddressSanitizer: negative-size-param: (size=-1)
    #0 __asan_memcpy
    #1 main repro_strncpy.c:28        <-- inside unsafe_yyjson_mut_strncpy
```

## Fix

Reject `len == (size_t)-1` at the top of `unsafe_yyjson_mut_str_alc()` so that
`len + 1` is always well-defined for the rest of the function. After the fix
the reproducer returns `NULL` (the documented error path for the public APIs)
instead of corrupting memory.

The pre-existing bound check in `unsafe_yyjson_str_pool_grow()`
(`len > USIZE_MAX - sizeof(yyjson_str_chunk)`) already rejects every other
oversize value cleanly; only the exact SIZE_MAX wrap-around needed an
additional guard.

## Test plan

* Configured with `-DYYJSON_BUILD_TESTS=ON -DYYJSON_SANITIZER=undefined` on
  Apple clang and rebuilt.
* `ctest` -- 12/12 tests pass.
* Reran the reproducer above; `yyjson_mut_strncpy` now returns `NULL` instead
  of triggering an ASan report.

Change is one file, four added lines (one branch + a short comment).