### PR TITLE
cap count in yyjson_mut_obj_with_str/_with_kv

### DIFF
--- a/src/yyjson.h
+++ b/src/yyjson.h
@@ -7020,7 +7020,9 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_with_str(yyjson_mut_doc *doc,
                                                           const char **keys,
                                                           const char **vals,
                                                           size_t count) {
-    if (yyjson_likely(doc && ((count > 0 && keys && vals) || (count == 0)))) {
+    if (yyjson_likely(doc && ((count > 0 && count <
+        (~(size_t)0) / sizeof(yyjson_mut_val) / 2 &&
+        keys && vals) || (count == 0)))) {
         yyjson_mut_val *obj = unsafe_yyjson_mut_val(doc, 1 + count * 2);
         if (yyjson_likely(obj)) {
             obj->tag = ((uint64_t)count << YYJSON_TAG_BIT) | YYJSON_TYPE_OBJ;
@@ -7050,7 +7052,9 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_with_str(yyjson_mut_doc *doc,
 yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_with_kv(yyjson_mut_doc *doc,
                                                          const char **pairs,
                                                          size_t count) {
-    if (yyjson_likely(doc && ((count > 0 && pairs) || (count == 0)))) {
+    if (yyjson_likely(doc && ((count > 0 && count <
+        (~(size_t)0) / sizeof(yyjson_mut_val) / 2 &&
+        pairs) || (count == 0)))) {
         yyjson_mut_val *obj = unsafe_yyjson_mut_val(doc, 1 + count * 2);
         if (yyjson_likely(obj)) {
             obj->tag = ((uint64_t)count << YYJSON_TAG_BIT) | YYJSON_TYPE_OBJ;


### PR DESCRIPTION
`yyjson_mut_obj_with_str` and `yyjson_mut_obj_with_kv` accept `count` and then pass `1 + count * 2` to `unsafe_yyjson_mut_val`; for `count > SIZE_MAX/2` that wraps to a tiny allocation while the loop still iterates `count` times and writes past the obj. The sibling `yyjson_mut_arr_with_func` macro already guards against this; mirroring that check (divided by 2 since the obj path doubles `count`) makes the function return NULL instead.