### PR TITLE
fix missing null terminator for raw numbers in yyjson_incr_read

### DIFF
--- a/src/yyjson.c
+++ b/src/yyjson.c
@@ -6534,6 +6534,8 @@ struct yyjson_incr_state {
     yyjson_val *val; /* current JSON value */
     yyjson_val *ctn; /* current container */
     u8 *str_con[2]; /* string parser incremental state */
+    u8 *raw_ptr; /* pending position for a deferred raw null-terminator */
+    u8 raw_end[1]; /* dummy target for the first deferred null-terminator */
 };
 
 yyjson_incr_state *yyjson_incr_new(char *buf, size_t buf_len,
@@ -6569,6 +6571,7 @@ yyjson_incr_state *yyjson_incr_new(char *buf, size_t buf_len,
     }
     memset(state->hdr + buf_len, 0, YYJSON_PADDING_SIZE);
     state->cur = state->hdr;
+    state->raw_ptr = state->raw_end;
     state->label = LABEL_doc_begin;
     return state;
 }
@@ -6633,6 +6636,7 @@ yyjson_doc *yyjson_incr_read(yyjson_incr_state *state, size_t len,
     state->val = val; \
     state->ctn_len = ctn_len; \
     state->hdr_len = hdr_len; \
+    state->raw_ptr = raw_ptr; \
     if (unlikely(cur >= end)) goto unexpected_end; \
 } while (false)
 
@@ -6664,8 +6668,7 @@ yyjson_doc *yyjson_incr_read(yyjson_incr_state *state, size_t len,
     const char *msg; /* error message */
 
     yyjson_read_err tmp_err;
-    u8 raw_end[1]; /* raw end for null-terminator */
-    u8 *raw_ptr = raw_end;
+    u8 *raw_ptr; /* deferred raw null-terminator position, committed at save */
     u8 **pre = &raw_ptr; /* previous raw end pointer */
     u8 **con = NULL; /* for incremental string parsing */
     u8 saved_end = '\0'; /* saved end char */
@@ -6700,6 +6703,7 @@ yyjson_doc *yyjson_incr_read(yyjson_incr_state *state, size_t len,
     val_end = state->val_end;
     ctn = state->ctn;
     con = state->str_con;
+    raw_ptr = state->raw_ptr;
     alc_max = USIZE_MAX / sizeof(yyjson_val);
 
     /* insert null terminator to make us stop at the specified end, even if

--- a/test/test_json_reader.c
+++ b/test/test_json_reader.c
@@ -686,8 +686,48 @@ error:
     return NULL;
 }
 
+/* Raw numbers parsed across incremental chunks must stay null-terminated,
+   matching the contract that yyjson_get_raw() returns a C string. */
+static void test_incr_raw_number_terminator(void) {
+    /* numbers wider than 64-bit so each one is raw under both flags */
+    const char *json = "[11111111111111111111111,22222222222222222222222,"
+                       "33333333333333333333333,44444444444444444444444]";
+    yyjson_read_flag flags[2] = {YYJSON_READ_NUMBER_AS_RAW,
+                                 YYJSON_READ_BIGNUM_AS_RAW};
+    usize f;
+    for (f = 0; f < 2; f++) {
+        usize len = strlen(json);
+        char *buf = malloc(len);
+        yyjson_incr_state *state;
+        yyjson_doc *doc = NULL;
+        usize read_len, idx, max;
+        yyjson_val *root, *val;
+        memcpy(buf, json, len);
+        state = yyjson_incr_new(buf, len, flags[f], NULL);
+        for (read_len = 1; read_len <= len; read_len++) {
+            yyjson_read_err err;
+            doc = yyjson_incr_read(state, read_len, &err);
+            if (doc) break;
+            yy_assert(err.code == YYJSON_READ_ERROR_MORE);
+        }
+        yy_assert(doc != NULL);
+        root = yyjson_doc_get_root(doc);
+        yyjson_arr_foreach(root, idx, max, val) {
+            const char *str = yyjson_get_raw(val);
+            usize slen = yyjson_get_len(val);
+            yy_assertf(str[slen] == '\0',
+                       "raw value '%.*s' is not null-terminated\n",
+                       (int)slen, str);
+        }
+        yyjson_doc_free(doc);
+        yyjson_incr_free(state);
+        free(buf);
+    }
+}
+
 // yyjson incremental with insitu
 static void test_json_incremental(void) {
+    test_incr_raw_number_terminator();
     char *dat = create_json(3, 10);
     usize len = strlen(dat);
     char *dat_dup = yy_str_copy(dat);


### PR DESCRIPTION
yyjson_incr_read() keeps the deferred raw null-terminator position in a per-call local, so a raw number (NUMBER_AS_RAW / BIGNUM_AS_RAW) that ends a chunk never gets terminated, and yyjson_get_raw() on it then reads past the value. Persist that position in yyjson_incr_state and commit it in save_incr_state so the '\0' lands at the right buffer offset across calls. Added a reader test that feeds such input one byte at a time.