### PR TITLE
reject NULL elements in yyjson_mut_obj_with_str/_with_kv

### DIFF
--- a/src/yyjson.h
+++ b/src/yyjson.h
@@ -7031,8 +7031,10 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_with_str(yyjson_mut_doc *doc,
                 for (i = 0; i < count; i++) {
                     yyjson_mut_val *key = obj + (i * 2 + 1);
                     yyjson_mut_val *val = obj + (i * 2 + 2);
-                    uint64_t key_len = (uint64_t)strlen(keys[i]);
-                    uint64_t val_len = (uint64_t)strlen(vals[i]);
+                    uint64_t key_len, val_len;
+                    if (yyjson_unlikely(!keys[i] || !vals[i])) return NULL;
+                    key_len = (uint64_t)strlen(keys[i]);
+                    val_len = (uint64_t)strlen(vals[i]);
                     key->tag = (key_len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
                     val->tag = (val_len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
                     key->uni.str = keys[i];
@@ -7065,8 +7067,10 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_with_kv(yyjson_mut_doc *doc,
                     yyjson_mut_val *val = obj + (i * 2 + 2);
                     const char *key_str = pairs[i * 2 + 0];
                     const char *val_str = pairs[i * 2 + 1];
-                    uint64_t key_len = (uint64_t)strlen(key_str);
-                    uint64_t val_len = (uint64_t)strlen(val_str);
+                    uint64_t key_len, val_len;
+                    if (yyjson_unlikely(!key_str || !val_str)) return NULL;
+                    key_len = (uint64_t)strlen(key_str);
+                    val_len = (uint64_t)strlen(val_str);
                     key->tag = (key_len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
                     val->tag = (val_len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
                     key->uni.str = key_str;

--- a/test/test_json_mut_val.c
+++ b/test/test_json_mut_val.c
@@ -1830,6 +1830,11 @@ static void test_json_mut_obj_api(void) {
         val = yyjson_mut_obj_get(obj, "c");
         yy_assert(yyjson_mut_equals_str(val, "z"));
         yyjson_mut_obj_clear(obj);
+
+        const char *keys_nul[3] = {"a", NULL, "c"};
+        yy_assert(!yyjson_mut_obj_with_str(doc, keys_nul, vals_str, 3));
+        const char *vals_nul[3] = {"x", "y", NULL};
+        yy_assert(!yyjson_mut_obj_with_str(doc, keys_str, vals_nul, 3));
     }
     {
         const char *pairs[6] = {"a", "x", "b", "y", "c", "z"};
@@ -1845,6 +1850,9 @@ static void test_json_mut_obj_api(void) {
         val = yyjson_mut_obj_get(obj, "c");
         yy_assert(yyjson_mut_equals_str(val, "z"));
         yyjson_mut_obj_clear(obj);
+
+        const char *pairs_nul[6] = {"a", "x", "b", NULL, "c", "z"};
+        yy_assert(!yyjson_mut_obj_with_kv(doc, pairs_nul, 3));
     }
     
     


### PR DESCRIPTION
The array builders (`yyjson_mut_arr_with_str` etc.) document that a NULL element makes them return NULL, and they check for it. `yyjson_mut_obj_with_str` and `yyjson_mut_obj_with_kv` take the same non-copied string arrays but feed each element straight to `strlen`, so a NULL key or value faults instead. Guard each element before `strlen`, like the array helpers do.