### PR TITLE
reject NULL raw pointer in yyjson_set_raw

### DIFF
--- a/src/yyjson.h
+++ b/src/yyjson.h
@@ -5427,6 +5427,7 @@ yyjson_api_inline bool yyjson_equals(const yyjson_val *lhs,
 yyjson_api_inline bool yyjson_set_raw(yyjson_val *val,
                                       const char *raw, size_t len) {
     if (yyjson_unlikely(!val || unsafe_yyjson_is_ctn(val))) return false;
+    if (yyjson_unlikely(!raw)) return false;
     unsafe_yyjson_set_raw(val, raw, len);
     return true;
 }

--- a/test/test_json_writer.c
+++ b/test/test_json_writer.c
@@ -933,6 +933,11 @@ yy_test_case(test_json_writer) {
         ret = yyjson_write(doc, 0, NULL);
         yy_assert(strcmp(ret, "[aaa]") == 0);
         free(ret);
+
+        yy_assert(!yyjson_set_raw(val, NULL, 3));
+        ret = yyjson_write(doc, 0, NULL);
+        yy_assert(strcmp(ret, "[aaa]") == 0);
+        free(ret);
         
         yyjson_set_null(val);
         ret = yyjson_write(doc, 0, NULL);


### PR DESCRIPTION
Noticed `yyjson_set_raw` stores its `raw` pointer without a NULL check, while `yyjson_set_strn` and `yyjson_mut_set_raw` both reject NULL. A NULL then reaches `memcpy` in `write_raw` when the value is serialized, so writing the document segfaults. Guard it like the sibling setters.