### PR TITLE
reject out-of-range prec in yyjson_set_fp_to_fixed/_mut

### DIFF
--- a/src/yyjson.h
+++ b/src/yyjson.h
@@ -5481,6 +5481,7 @@ yyjson_api_inline bool yyjson_set_real(yyjson_val *val, double num) {
 
 yyjson_api_inline bool yyjson_set_fp_to_fixed(yyjson_val *val, int prec) {
     if (yyjson_unlikely(!yyjson_is_real(val))) return false;
+    if (yyjson_unlikely((unsigned)prec > 15)) return false;
     unsafe_yyjson_set_fp_to_fixed(val, prec);
     return true;
 }
@@ -6042,6 +6043,7 @@ yyjson_api_inline bool yyjson_mut_set_real(yyjson_mut_val *val, double num) {
 yyjson_api_inline bool yyjson_mut_set_fp_to_fixed(yyjson_mut_val *val,
                                                   int prec) {
     if (yyjson_unlikely(!yyjson_mut_is_real(val))) return false;
+    if (yyjson_unlikely((unsigned)prec > 15)) return false;
     unsafe_yyjson_set_fp_to_fixed(val, prec);
     return true;
 }

--- a/test/test_number.c
+++ b/test/test_number.c
@@ -1433,6 +1433,10 @@ static void test_write_flags(void) {
         yyjson_set_fp_to_fixed(&val, 12);
         yy_assert(yyjson_is_real(&val));
         yy_assert((val.tag >> 32) == YYJSON_WRITE_FP_TO_FIXED(12));
+        yy_assert(!yyjson_set_fp_to_fixed(&val, -1));
+        yy_assert(!yyjson_set_fp_to_fixed(&val, 16));
+        yy_assert(!yyjson_set_fp_to_fixed(&val, 17));
+        yy_assert((val.tag >> 32) == YYJSON_WRITE_FP_TO_FIXED(12));
         yyjson_set_fp_to_fixed(&val, 0);
         yy_assert(yyjson_is_real(&val));
         yy_assert((val.tag >> 32) == YYJSON_WRITE_FP_TO_FIXED(0));
@@ -1461,6 +1465,10 @@ static void test_write_flags(void) {
         /// set to fixed
         yyjson_mut_set_fp_to_fixed(&val, 12);
         yy_assert(yyjson_mut_is_real(&val));
+        yy_assert((val.tag >> 32) == YYJSON_WRITE_FP_TO_FIXED(12));
+        yy_assert(!yyjson_mut_set_fp_to_fixed(&val, -1));
+        yy_assert(!yyjson_mut_set_fp_to_fixed(&val, 16));
+        yy_assert(!yyjson_mut_set_fp_to_fixed(&val, 17));
         yy_assert((val.tag >> 32) == YYJSON_WRITE_FP_TO_FIXED(12));
         yyjson_mut_set_fp_to_fixed(&val, 0);
         yy_assert(yyjson_mut_is_real(&val));


### PR DESCRIPTION
yyjson_set_fp_to_fixed and yyjson_mut_set_fp_to_fixed pass `prec`
through unchanged to `(uint32_t)prec << 28`, which silently truncates
the high bits. prec=17 wraps to prec=1 and emits "1.2" instead of
rejecting the input; prec=16 wraps to 0 and quietly disables the
fixed mode; prec=-1 stores as prec=15. Reject any prec outside
[0, 15] (0 is still accepted as the documented "clear" value used
by the existing tests) before touching the tag. Full ctest suite
(12/12) passes; existing tests for prec=0 and prec=12 still work
and a regression assertion is added for -1/16/17.