### PR TITLE
handle ftell failure after SEEK_END in yyjson_read_fp

### DIFF
--- a/src/yyjson.c
+++ b/src/yyjson.c
@@ -6367,7 +6367,10 @@ yyjson_doc *yyjson_read_fp(FILE *file,
     file_pos = ftell(file);
     if (file_pos != -1) {
         /* get total file size, may fail */
-        if (fseek(file, 0, SEEK_END) == 0) file_size = ftell(file);
+        if (fseek(file, 0, SEEK_END) == 0) {
+            file_size = ftell(file);
+            if (file_size == -1) file_size = 0;
+        }
         /* reset to original position, may fail */
         if (fseek(file, file_pos, SEEK_SET) != 0) file_size = 0;
         /* get file size from current position to end */


### PR DESCRIPTION
Noticed `yyjson_read_fp` stores the result of `ftell` after `SEEK_END` into `file_size` (long) without checking for -1. On a seekable file where the second `ftell` fails (e.g. EOVERFLOW on a >2GB file with a 32-bit `long`, or any file >2GB on MSVC where `ftell` is always `long`), `file_size` becomes -1 and the `file_size > 0` guard skips the `-= file_pos` adjustment. The stream-read fallback then starts from -1 and ends one short, so the trailing null-padding overwrites the last data byte and `yyjson_read_opts` is called with len = total_read - 1. Reset `file_size` to 0 if the inner `ftell` fails, matching the existing fallback in the sibling `fseek` branch.