### PR TITLE
fix null pointer subtraction in unsafe_yyjson_mut_ptr_putx

### DIFF
--- a/src/yyjson.c
+++ b/src/yyjson.c
@@ -10757,7 +10757,7 @@ bool unsafe_yyjson_mut_ptr_putx(
             val = NULL;
             ctn_type = YYJSON_TYPE_OBJ;
             token = ptr_next_token(&ptr, end, &token_len, &esc);
-            if (unlikely(!token)) return_err_resolve(false, token - hdr);
+            if (unlikely(!token)) return_err_syntax(false, ptr - hdr);
         }
 
         /* container is object, create parent nodes */

--- a/src/yyjson.h
+++ b/src/yyjson.h
@@ -6989,7 +6989,7 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_getn(
             cur = cur->next->next;
             if (unsafe_yyjson_equals_strn(cur, key, key_len)) {
                 iter->idx += idx;
-                if (iter->idx > max) iter->idx -= max + 1;
+                if (iter->idx > max) iter->idx -= max;
                 iter->pre = pre;
                 iter->cur = cur;
                 return cur->next;

--- a/test/test_json_mut_val.c
+++ b/test/test_json_mut_val.c
@@ -1944,8 +1944,22 @@ static void test_json_mut_obj_api(void) {
     yy_assert(yyjson_mut_get_int(yyjson_mut_obj_iter_get(&iter, "b")) == 11);
     yy_assert(yyjson_mut_get_int(yyjson_mut_obj_iter_get(&iter, "a")) == 10);
     yy_assert(!yyjson_mut_obj_iter_get(&iter, "x"));
-    
-    
+
+    // keyed lookup that wraps past the end must keep iter->idx in sync so a
+    // following remove updates the obj tail; otherwise the tail key is left
+    // dangling.
+    yyjson_mut_obj_iter_init(obj, &iter);
+    while (yyjson_mut_obj_iter_next(&iter)) {}
+    yy_assert(yyjson_mut_get_int(yyjson_mut_obj_iter_get(&iter, "c")) == 12);
+    yy_assert(yyjson_mut_obj_iter_remove(&iter));
+    set_validate(0, "a", 1, 10);
+    set_validate(1, "b", 1, 11);
+    validate_mut_obj(obj, keys, key_lens, vals, 2);
+    yy_assert(yyjson_mut_obj_add_int(doc, obj, "d", 13));
+    set_validate(2, "d", 1, 13);
+    validate_mut_obj(obj, keys, key_lens, vals, 3);
+
+
     yyjson_mut_obj_clear(obj);
     
     

--- a/test/test_json_pointer.c
+++ b/test/test_json_pointer.c
@@ -2077,7 +2077,17 @@ static void test_ptr_put(void) {
         .err = YYJSON_PTR_ERR_RESOLVE,
         .pos = 1,
     });
-    
+    test_ptr_op((ptr_data){
+        .op = PTR_OP_ADD,
+        .src = "[1,2]",
+        .ptr = "/-/~2", // invalid escape after array append slot
+        .val = "1",
+        .dst = "[1,2]",
+        .create_parent = true,
+        .err = YYJSON_PTR_ERR_SYNTAX,
+        .pos = 3,
+    });
+
     // ---------------------------------
     // parent type not matched (not container)
     test_ptr_op((ptr_data){


### PR DESCRIPTION
On the array parent-creation branch, ptr_next_token returns NULL when the next token has an invalid escape, so the error position is computed as token - hdr (subtraction from NULL) with the wrong RESOLVE code; switch to ptr - hdr with the syntax error like the sibling guards. Triggered by yyjson_mut_ptr_add on an array with a pointer like "/-/~2".