### PR TITLE
fix premature finalization of root number in yyjson_incr_read

### DIFF
--- a/src/yyjson.c
+++ b/src/yyjson.c
@@ -6769,7 +6769,11 @@ doc_begin:
         goto arr_val_begin;
     }
     if (char_is_num(*cur)) {
-        if (likely(read_num(&cur, pre, flg, val, &msg))) goto doc_end;
+        if (likely(read_num(&cur, pre, flg, val, &msg))) {
+            /* a root number may continue with more digits in a later chunk */
+            if (unlikely(len < state->buf_len)) check_maybe_truncated_number();
+            goto doc_end;
+        }
         goto fail_number;
     }
     if (*cur == '"') {

--- a/test/test_json_reader.c
+++ b/test/test_json_reader.c
@@ -725,9 +725,38 @@ static void test_incr_raw_number_terminator(void) {
     }
 }
 
+/* A root-level number must not be finalized while more data is still pending;
+   it may continue with more digits in a later chunk (same as numbers inside a
+   container). Feeding "743" one byte at a time must yield 743, not 7. */
+static void test_incr_root_number_truncation(void) {
+    const char *json = "743";
+    usize len = strlen(json);
+    char *buf = malloc(len);
+    yyjson_incr_state *state;
+    yyjson_doc *doc = NULL;
+    usize read_len;
+    memcpy(buf, json, len);
+    state = yyjson_incr_new(buf, len, 0, NULL);
+    for (read_len = 1; read_len <= len; read_len++) {
+        yyjson_read_err err;
+        doc = yyjson_incr_read(state, read_len, &err);
+        if (doc) {
+            yy_assert(read_len == len);
+            break;
+        }
+        yy_assert(err.code == YYJSON_READ_ERROR_MORE);
+    }
+    yy_assert(doc != NULL);
+    yy_assert(yyjson_get_sint(yyjson_doc_get_root(doc)) == 743);
+    yyjson_doc_free(doc);
+    yyjson_incr_free(state);
+    free(buf);
+}
+
 // yyjson incremental with insitu
 static void test_json_incremental(void) {
     test_incr_raw_number_terminator();
+    test_incr_root_number_truncation();
     char *dat = create_json(3, 10);
     usize len = strlen(dat);
     char *dat_dup = yy_str_copy(dat);


### PR DESCRIPTION
A root-level number ending exactly at the available-data boundary was finalized instead of requesting more, so feeding `743` byte by byte parsed as 7 rather than 743; the in-container number paths already guard this case via check_maybe_truncated_number.