### PR TITLE
fix zero-length fwrite reporting failure in file writers

### DIFF
--- a/src/yyjson.c
+++ b/src/yyjson.c
@@ -9068,7 +9068,7 @@ static_inline u8 *write_indent(u8 *cur, usize level, usize spaces) {
 /** Write data to file pointer. */
 static bool write_dat_to_fp(FILE *fp, u8 *dat, usize len,
                             yyjson_write_err *err) {
-    if (fwrite(dat, len, 1, fp) != 1) {
+    if (fwrite(dat, 1, len, fp) != len) {
         err->msg = "file writing failed";
         err->code = YYJSON_WRITE_ERROR_FILE_WRITE;
         return false;
@@ -9090,7 +9090,7 @@ static bool write_dat_to_file(const char *path, u8 *dat, usize len,
     if (file == NULL) {
         return_err(FILE_OPEN, MSG_FOPEN);
     }
-    if (fwrite(dat, len, 1, file) != 1) {
+    if (fwrite(dat, 1, len, file) != len) {
         return_err(FILE_WRITE, MSG_FWRITE);
     }
     if (fclose(file) != 0) {

--- a/test/test_json_writer.c
+++ b/test/test_json_writer.c
@@ -854,7 +854,36 @@ yy_test_case(test_json_writer) {
         yyjson_mut_write_file("", NULL, 0, NULL, NULL);
         yyjson_mut_write_file("tmp.json", NULL, 0, NULL, NULL);
     }
-    
+
+    // test zero-length output (empty raw root) to file
+    {
+        const char *tmp_file_path = "__yyjson_test_empty__.json";
+        u8 *dat;
+        usize dat_len;
+        FILE *tmp_fp;
+        yyjson_mut_doc *doc = yyjson_mut_doc_new(NULL);
+        yyjson_mut_doc_set_root(doc, yyjson_mut_rawn(doc, "", 0));
+
+        usize len;
+        char *ret = yyjson_mut_write(doc, 0, &len);
+        yy_assert(ret && len == 0);
+        free(ret);
+
+        yy_file_delete(tmp_file_path);
+        yy_assert(yyjson_mut_write_file(tmp_file_path, doc, 0, NULL, NULL));
+        yy_assert(yy_file_read(tmp_file_path, &dat, &dat_len));
+        yy_assert(dat_len == 0);
+        free(dat);
+        yy_file_delete(tmp_file_path);
+
+        tmp_fp = yy_file_open(tmp_file_path, "wb");
+        yy_assert(yyjson_mut_write_fp(tmp_fp, doc, 0, NULL, NULL));
+        fclose(tmp_fp);
+        yy_file_delete(tmp_file_path);
+
+        yyjson_mut_doc_free(doc);
+    }
+
 #if !YYJSON_DISABLE_READER
     // test invalid immutable doc
     {


### PR DESCRIPTION
Hit this while exercising the write-to-file path. A document that serializes to nothing, an empty raw root such as `yyjson_mut_rawn(doc, "", 0)`, writes fine to a string (len 0) but `yyjson_mut_write_file`/`yyjson_mut_write_fp` return `YYJSON_WRITE_ERROR_FILE_WRITE`. `write_dat_to_fp`/`write_dat_to_file` call `fwrite(dat, len, 1, fp)` and C makes fwrite return 0 when len is 0, so the `!= 1` check trips on a successful zero-byte write. Switched both to the `fwrite(dat, 1, len, fp) != len` form already used by the fread side.