### PR TITLE
fix size overflow in pretty writer string length reservation

### DIFF
--- a/src/yyjson.c
+++ b/src/yyjson.c
@@ -9512,6 +9512,8 @@ val_begin:
         str_len = unsafe_yyjson_get_len(val);
         str_ptr = (const u8 *)unsafe_yyjson_get_str(val);
         check_str_len(str_len);
+        if ((sizeof(usize) < 8) && !no_indent &&
+            level > (USIZE_MAX - 16 - str_len * 6) / 4) goto fail_alloc;
         incr_len(str_len * 6 + 16 + (no_indent ? 0 : level * 4));
         cur = write_indent(cur, no_indent ? 0 : level, spaces);
         if (likely(cpy) && unsafe_yyjson_get_subtype(val)) {
@@ -10118,6 +10120,8 @@ val_begin:
         str_len = unsafe_yyjson_get_len(val);
         str_ptr = (const u8 *)unsafe_yyjson_get_str(val);
         check_str_len(str_len);
+        if ((sizeof(usize) < 8) && !no_indent &&
+            level > (USIZE_MAX - 16 - str_len * 6) / 4) goto fail_alloc;
         incr_len(str_len * 6 + 16 + (no_indent ? 0 : level * 4));
         cur = write_indent(cur, no_indent ? 0 : level, spaces);
         if (likely(cpy) && unsafe_yyjson_get_subtype(val)) {


### PR DESCRIPTION
on 32-bit the pretty writers reserve str_len*6+16+level*4 but check_str_len only bounds str_len*6+16, so a deeply nested long string overflows the size and under-allocates before write_str.