### PR TITLE
reset iter->pre after removing an element from an iterator

### DIFF
--- a/src/yyjson.h
+++ b/src/yyjson.h
@@ -6386,7 +6386,8 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_iter_next(
 
 yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_iter_remove(
     yyjson_mut_arr_iter *iter) {
-    if (yyjson_likely(iter && 0 < iter->idx && iter->idx <= iter->max)) {
+    if (yyjson_likely(iter && iter->pre &&
+                      0 < iter->idx && iter->idx <= iter->max)) {
         yyjson_mut_val *prev = iter->pre;
         yyjson_mut_val *cur = iter->cur;
         yyjson_mut_val *next = cur->next;
@@ -6396,6 +6397,7 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_iter_remove(
         unsafe_yyjson_set_len(iter->arr, iter->max);
         prev->next = next;
         iter->cur = prev;
+        iter->pre = NULL;
         return cur;
     }
     return NULL;
@@ -7036,7 +7038,8 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_get_val(
 
 yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_remove(
     yyjson_mut_obj_iter *iter) {
-    if (yyjson_likely(iter && 0 < iter->idx && iter->idx <= iter->max)) {
+    if (yyjson_likely(iter && iter->pre &&
+                      0 < iter->idx && iter->idx <= iter->max)) {
         yyjson_mut_val *prev = iter->pre;
         yyjson_mut_val *cur = iter->cur;
         yyjson_mut_val *next = cur->next->next;
@@ -7046,6 +7049,7 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_remove(
         unsafe_yyjson_set_len(iter->obj, iter->max);
         prev->next->next = next;
         iter->cur = prev;
+        iter->pre = NULL;
         return cur->next;
     }
     return NULL;

--- a/test/test_json_mut_val.c
+++ b/test/test_json_mut_val.c
@@ -836,6 +836,25 @@ static void test_json_mut_arr_api(void) {
     
     
     //---------------------------------------------
+    // iterator with remove() called twice in a row
+
+    yyjson_mut_arr_append(arr, num1);
+    yyjson_mut_arr_append(arr, num2);
+    yyjson_mut_arr_append(arr, num3);
+
+    cmp[0] = 1;
+    cmp[1] = 3;
+    yyjson_mut_arr_iter_init(arr, &iter);
+    yyjson_mut_arr_iter_next(&iter);
+    val = yyjson_mut_arr_iter_next(&iter);
+    yy_assert(yyjson_mut_arr_iter_remove(&iter) == val);
+    yy_assert(yyjson_mut_arr_iter_remove(&iter) == NULL);
+    validate_mut_arr(arr, cmp, 2);
+    
+    yyjson_mut_arr_clear(arr);
+    
+    
+    //---------------------------------------------
     // array add()
     val = yyjson_mut_str(doc, "abc");
     yy_assert(!yyjson_mut_arr_add_val(NULL, NULL));
@@ -2138,6 +2157,25 @@ static void test_json_mut_obj_api(void) {
     yyjson_mut_obj_clear(obj);
     
     yy_assert(!yyjson_mut_obj_iter_remove(NULL));
+    
+    
+    //---------------------------------------------
+    // iterator with remove() called twice in a row
+
+    yyjson_mut_obj_add_int(doc, obj, "a", 10);
+    yyjson_mut_obj_add_int(doc, obj, "b", 11);
+    yyjson_mut_obj_add_int(doc, obj, "c", 12);
+
+    yyjson_mut_obj_iter_init(obj, &iter);
+    yyjson_mut_obj_iter_next(&iter);
+    key = yyjson_mut_obj_iter_next(&iter);
+    val = yyjson_mut_obj_iter_get_val(key);
+    yy_assert(yyjson_mut_obj_iter_remove(&iter) == val);
+    yy_assert(yyjson_mut_obj_iter_remove(&iter) == NULL);
+    set_validate(0, "a", 1, 10);
+    set_validate(1, "c", 1, 12);
+    validate_mut_obj(obj, keys, key_lens, vals, 2);
+    yyjson_mut_obj_clear(obj);
     
     
     yyjson_mut_obj_clear(NULL);


### PR DESCRIPTION
yyjson_mut_arr_iter_remove and yyjson_mut_obj_iter_remove rewind iter->cur to the removed element's predecessor but leave iter->pre pointing at that same node, so pre is no longer the previous value once a remove has happened. Since pre is only read by these two functions, the state survives unnoticed until remove is called a second time without an intervening next(): prev and cur are then the same node, the relink becomes a no-op, but idx, max and the container length are still decremented and the tail pointer may be overwritten.

The effect is that the second call hands back an element which is still linked into the container while the stored length no longer matches the ring, so a caller that inserts the returned value somewhere else quietly ends up with the same node under two parents. On a three element array a next/next/remove/remove sequence returns element 0 and leaves the array reporting size 1 whilst still serialising that element; the object iterator behaves the same way.

This clears pre after unlinking and requires it in the guard, which matches what yyjson_ptr_ctx_remove already does in the same header, so a repeated remove returns NULL rather than corrupting the container. Regression tests for both iterators are included and fail without the change.